### PR TITLE
local tarball dependency handler

### DIFF
--- a/lib/handlers/local/manifest.js
+++ b/lib/handlers/local/manifest.js
@@ -1,0 +1,31 @@
+var extractFiles = require('../../util/extract-files')
+var tarball = require('./tarball')
+
+module.exports = manifest
+function manifest (spec, opts, cb) {
+  var stream = tarball(spec, opts)
+  stream.on('data', function () {})
+  extractFiles(stream, [
+    'package.json', 'npm-shrinkwrap.json'
+  ], opts, function (err, files) {
+    if (err) { return cb(err) }
+    if (!files['package.json']) {
+      return cb(new Error('no package.json found'))
+    } else {
+      try {
+        var pkg = JSON.parse(files['package.json'])
+      } catch (e) {
+        return cb(e)
+      }
+      if (files['npm-shrinkwrap.json']) {
+        try {
+          var sr = JSON.parse(files['npm-shrinkwrap.json'])
+        } catch (e) {
+          return cb(e)
+        }
+        pkg._shrinkwrap = sr
+      }
+      cb(null, pkg)
+    }
+  })
+}

--- a/lib/handlers/local/tarball.js
+++ b/lib/handlers/local/tarball.js
@@ -1,0 +1,6 @@
+var fs = require('fs')
+
+module.exports = tarball
+function tarball (spec, opts) {
+  return fs.createReadStream(spec.spec)
+}

--- a/lib/util/extract-files.js
+++ b/lib/util/extract-files.js
@@ -1,0 +1,48 @@
+var finished = require('mississippi').finished
+var gunzip = require('./gunzip-maybe')
+var pipe = require('mississippi').pipe
+var pipeline = require('mississippi').pipeline
+
+var tar = require('tar-stream')
+
+module.exports = extractFiles
+function extractFiles (pkgStream, files, opts, cb) {
+  if (typeof files === 'string') {
+    files = [files]
+  }
+  files = files.map(function (f) { return 'package/' + f })
+  var extract = tar.extract()
+
+  var unzipped = pipeline(gunzip(), extract)
+
+  var found = {}
+  extract.on('entry', function onEntry (header, fileStream, next) {
+    if (files.indexOf(header.name) !== -1) {
+      var data = ''
+      fileStream.on('data', function (d) { data += d })
+
+      finished(fileStream, function (err) {
+        if (err) { return extract.emit('error', err) }
+        found[header.name.replace('package/', '')] = data
+        files = files.filter(function (f) { return f !== header.name })
+        if (files.length === 0) {
+          unzipped.unpipe()
+          cb(null, found)
+        } else {
+          next()
+        }
+      })
+    } else {
+      // Not a shrinkwrap. Autodrain this entry, and move on to the next.
+      fileStream.resume()
+      next()
+    }
+  })
+
+  // Any other streams that `pkgStream` is being piped to should
+  // remain unaffected by this, although there might be confusion
+  // around backpressure issues.
+  pipe(pkgStream, unzipped, function (err) {
+    if (files.length) { cb(err, found, files) }
+  })
+}

--- a/test/local.manifest.js
+++ b/test/local.manifest.js
@@ -1,0 +1,23 @@
+var npmlog = require('npmlog')
+var path = require('path')
+var test = require('tap').test
+
+npmlog.level = process.env.LOGLEVEL || 'silent'
+var OPTS = {
+  log: npmlog
+}
+
+var manifest = require('../manifest')
+
+test('basic local manifest read', function (t) {
+  var p = path.join(__dirname, './fixtures/has-shrinkwrap.tgz')
+  manifest(p, OPTS, function (err, pkg) {
+    if (err) { throw err }
+    t.ok(pkg, 'got a package manifest')
+    t.equal(pkg.name, 'test', 'parsed and read correctly')
+    t.equal(pkg._shrinkwrap.name, 'test', 'got a shrinkwrap')
+    t.done()
+  })
+})
+
+test('accepts `where` opt to specify base for parsing')

--- a/test/local.tarball.js
+++ b/test/local.tarball.js
@@ -1,0 +1,33 @@
+var fs = require('fs')
+var npmlog = require('npmlog')
+var path = require('path')
+var test = require('tap').test
+var testDir = require('./util/test-dir')
+
+var TMP = testDir(__filename)
+
+npmlog.level = process.env.LOGLEVEL || 'silent'
+var OPTS = {
+  log: npmlog
+}
+
+var extract = require('../extract')
+
+test('basic tarball extraction', function (t) {
+  t.plan(2)
+  var p = path.join(__dirname, './fixtures/has-shrinkwrap.tgz')
+  var d = path.join(TMP, 'extracted')
+  extract(p, d, OPTS, function (err) {
+    if (err) { throw err }
+    var pkg = path.join(d, 'package.json')
+    var sr = path.join(d, 'npm-shrinkwrap.json')
+    fs.readFile(pkg, 'utf8', function (err, data) {
+      if (err) { throw err }
+      t.equal(JSON.parse(data).name, 'test', 'got the package.json!')
+    })
+    fs.readFile(sr, 'utf8', function (err, data) {
+      if (err) { throw err }
+      t.equal(JSON.parse(data).name, 'test', 'got the shrinkwrap!')
+    })
+  })
+})


### PR DESCRIPTION
Fixes #7 

## TODO

- [ ] More detailed tests
- [ ] Include a refactor to replace `extract-shrinkwrap`
- [ ] Specific tests for `extract-stream`
- [ ] Add support for and test `where` option (passed to `realize-package-specifier`)