### PR TITLE
Add hosted git support

### DIFF
--- a/lib/handlers/hosted/manifest.js
+++ b/lib/handlers/hosted/manifest.js
@@ -1,0 +1,17 @@
+var optCheck = require('../../util/opt-check')
+var request = require('../../registry/request')
+
+module.exports = manifest
+function manifest (spec, opts, cb) {
+  opts = optCheck(opts)
+  var h = spec.hosted
+  request(h.directUrl, h.type, opts, function (err, manifest) {
+    if (err) { return cb(err) }
+    var srUrl = h.directUrl.replace(/package\.json/, 'npm-shrinkwrap.json')
+    request(srUrl, h.type, opts, function (err, sr) {
+      if (err && err.statusCode !== 404) { return cb(err) }
+      manifest._shrinkwrap = sr
+      cb(null, manifest)
+    })
+  })
+}

--- a/lib/handlers/hosted/tarball.js
+++ b/lib/handlers/hosted/tarball.js
@@ -1,0 +1,14 @@
+var hostedGitInfo = require('hosted-git-info')
+var optCheck = require('../../util/opt-check')
+var request = require('../../registry/request')
+
+module.exports = tarball
+function tarball (spec, opts) {
+  opts = optCheck(opts)
+  return request.stream(tarballURI(spec), spec.hosted.type, opts)
+}
+
+// TODO - this requires a new hosted-git-info
+function tarballURI (spec) {
+  return hostedGitInfo.fromUrl(spec.hosted.ssh).tarball()
+}

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "cacache": "^6.0.1",
     "checksum-stream": "^1.0.2",
     "dezalgo": "^1.0.3",
+    "hosted-git-info": "^2.2.0",
     "inflight": "^1.0.6",
     "minimatch": "^3.0.3",
     "mississippi": "^1.2.0",


### PR DESCRIPTION
Fixes #4 

This handles git dependencies hosted at places like github, gitlab, and bitbucket. It fast-paths straight to their respective tarball and direct file downloads by default.

There's a few things pending:

- [x] get https://github.com/npm/hosted-git-info/pull/21 merged and the dep updated (don't need to update it inside `realize-package-specifier` -- we can just call it directly)
- [ ] regular `git clone` fallback(s) (so, #5 needs to be done before this one can get merged).
- [ ] tests
- [ ] 404 handling (errors from our `request` are kinda janky tbh)
- [ ] version range support (maybe this is best left until later, too)