### PR TITLE
Fixes #19: add 'use strict' to all .js files

### DIFF
--- a/extract.js
+++ b/extract.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var cache = require('./lib/cache')
 var extractStream = require('./lib/util/extract-stream')
 var pipe = require('mississippi').pipe

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict'
+
 module.exports = {
   extract: require('./extract'),
   manifest: require('./manifest')

--- a/lib/cache/cache-key.js
+++ b/lib/cache/cache-key.js
@@ -1,3 +1,5 @@
+'use strict'
+
 module.exports = cacheKey
 function cacheKey (type, identifier) {
   return ['pacote', type, identifier].join(':')

--- a/lib/cache/index.js
+++ b/lib/cache/index.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var cacache = require('cacache')
 var cacheKey = require('./cache-key')
 var finished = require('mississippi').finished

--- a/lib/handlers/range/manifest.js
+++ b/lib/handlers/range/manifest.js
@@ -1,1 +1,3 @@
+'use strict'
+
 module.exports = require('../../registry/manifest')

--- a/lib/handlers/range/tarball.js
+++ b/lib/handlers/range/tarball.js
@@ -1,1 +1,3 @@
+'use strict'
+
 module.exports = require('../../registry/tarball')

--- a/lib/handlers/tag/manifest.js
+++ b/lib/handlers/tag/manifest.js
@@ -1,1 +1,3 @@
+'use strict'
+
 module.exports = require('../../registry/manifest')

--- a/lib/handlers/tag/tarball.js
+++ b/lib/handlers/tag/tarball.js
@@ -1,1 +1,3 @@
+'use strict'
+
 module.exports = require('../../registry/tarball')

--- a/lib/handlers/version/manifest.js
+++ b/lib/handlers/version/manifest.js
@@ -1,1 +1,3 @@
+'use strict'
+
 module.exports = require('../../registry/manifest')

--- a/lib/handlers/version/tarball.js
+++ b/lib/handlers/version/tarball.js
@@ -1,1 +1,3 @@
+'use strict'
+
 module.exports = require('../../registry/tarball')

--- a/lib/registry/manifest.js
+++ b/lib/registry/manifest.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var extractShrinkwrap = require('../util/extract-shrinkwrap')
 var optCheck = require('../util/opt-check')
 var pickManifest = require('./pick-manifest')

--- a/lib/registry/pick-manifest.js
+++ b/lib/registry/pick-manifest.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var semver = require('semver')
 
 module.exports = pickManifest

--- a/lib/registry/pick-registry.js
+++ b/lib/registry/pick-registry.js
@@ -1,3 +1,5 @@
+'use strict'
+
 module.exports = pickRegistry
 function pickRegistry (spec, opts) {
   var registry = spec.scope && opts[spec.scope + ':registry']

--- a/lib/registry/registry-key.js
+++ b/lib/registry/registry-key.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var url = require('url')
 
 // Called a nerf dart in the main codebase. Used as a "safe"

--- a/lib/registry/request.js
+++ b/lib/registry/request.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var cache = require('../cache')
 var finished = require('mississippi').finished
 var inflight = require('inflight')

--- a/lib/registry/tarball.js
+++ b/lib/registry/tarball.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var manifest = require('./manifest')
 var optCheck = require('../util/opt-check')
 var pickRegistry = require('./pick-registry')

--- a/lib/util/extract-shrinkwrap.js
+++ b/lib/util/extract-shrinkwrap.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var finished = require('mississippi').finished
 var gunzip = require('./gunzip-maybe')
 var pipe = require('mississippi').pipe

--- a/lib/util/extract-stream.js
+++ b/lib/util/extract-stream.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var gunzip = require('./gunzip-maybe')
 var path = require('path')
 var pipeline = require('mississippi').pipeline

--- a/lib/util/gunzip-maybe.js
+++ b/lib/util/gunzip-maybe.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var duplex = require('mississippi').duplex
 var through = require('mississippi').through
 var zlib = require('zlib')

--- a/lib/util/opt-check.js
+++ b/lib/util/opt-check.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var silentlog = require('./silentlog')
 
 function PacoteOptions (opts) {

--- a/lib/util/silentlog.js
+++ b/lib/util/silentlog.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var noop = Function.prototype
 module.exports = {
   error: noop,

--- a/manifest.js
+++ b/manifest.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var optCheck = require('./lib/util/opt-check')
 var rps = require('realize-package-specifier')
 

--- a/test/cache.js
+++ b/test/cache.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var crypto = require('crypto')
 var finished = require('mississippi').finished
 var fromString = require('./util/from-string')

--- a/test/docs.js
+++ b/test/docs.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var fs = require('fs')
 var path = require('path')
 var test = require('tap').test

--- a/test/extract.js
+++ b/test/extract.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var test = require('tap').test
 
 test('basic registry package extraction')

--- a/test/registry.get.js
+++ b/test/registry.get.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var test = require('tap').test
 
 test('basic streaming uri request')

--- a/test/registry.manifest.cache.js
+++ b/test/registry.manifest.cache.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var cache = require('../lib/cache')
 var npmlog = require('npmlog')
 var test = require('tap').test

--- a/test/registry.manifest.js
+++ b/test/registry.manifest.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var npmlog = require('npmlog')
 var test = require('tap').test
 var tnock = require('./util/tnock')

--- a/test/registry.manifest.shrinkwrap.js
+++ b/test/registry.manifest.shrinkwrap.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var npmlog = require('npmlog')
 var tar = require('tar-stream')
 var test = require('tap').test

--- a/test/registry.pick-manifest.js
+++ b/test/registry.pick-manifest.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var test = require('tap').test
 
 var pickManifest = require('../lib/registry/pick-manifest')

--- a/test/registry.tarball.js
+++ b/test/registry.tarball.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var test = require('tap').test
 
 test('basic tarball streaming')

--- a/test/util.extract-shrinkwrap.js
+++ b/test/util.extract-shrinkwrap.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var fs = require('fs')
 var npmlog = require('npmlog')
 var pipe = require('mississippi').pipe

--- a/test/util/from-string.js
+++ b/test/util/from-string.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var through = require('mississippi').through
 
 module.exports = fromString

--- a/test/util/test-dir.js
+++ b/test/util/test-dir.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var mkdirp = require('mkdirp')
 var path = require('path')
 var rimraf = require('rimraf')

--- a/test/util/tnock.js
+++ b/test/util/tnock.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var nock = require('nock')
 var clearMemoized = require('../../lib/cache')._clearMemoized
 


### PR DESCRIPTION
This PR adds 'use strict' to all JavaScript files in Pacote. 🌞 