### PR TITLE
fix(manifest): ETARGET when no packages match

### DIFF
--- a/lib/registry/pick-manifest.js
+++ b/lib/registry/pick-manifest.js
@@ -12,7 +12,7 @@ function pickManifest (metadata, spec, opts) {
   var err
   return BB.fromNode(cb => {
     if (!versions.length) {
-      err = new Error('Package has no valid versions.')
+      err = new Error(`No valid versions available for ${metadata.name}`)
       err.code = 'ENOVERSIONS'
       err.name = metadata.name
       err.spec = spec
@@ -56,8 +56,8 @@ function pickManifest (metadata, spec, opts) {
 
     var manifest = target && metadata.versions[target]
     if (!manifest) {
-      err = new Error('No matching versions')
-      err.code = 'ENOENT'
+      err = new Error(`No matching version found for ${spec.name}@${spec.spec}`)
+      err.code = 'ETARGET'
       err.name = metadata.name
       err.spec = spec
       err.versions = versions

--- a/test/registry.pick-manifest.js
+++ b/test/registry.pick-manifest.js
@@ -122,7 +122,7 @@ test('skips any invalid version keys', t => {
       () => { throw new Error('expected a failure') },
       err => {
         t.ok(err, 'got an error')
-        t.equal(err.code, 'ENOENT', 'no matching specs')
+        t.equal(err.code, 'ETARGET', 'no matching specs')
       }
     )
   )
@@ -140,7 +140,7 @@ test('ENOENT if range does not match anything', t => {
     () => { throw new Error('expected a failure') },
     err => {
       t.ok(err, 'got an error')
-      t.equal(err.code, 'ENOENT', 'useful error code returned.')
+      t.equal(err.code, 'ETARGET', 'useful error code returned.')
     }
   )
 })


### PR DESCRIPTION
Fixes: #34

This brings pick-manifest more in line with npm on this matter.

<!--
⚠️🚨 BEFORE FILING A PR: 🚨⚠️

👉🏼 CONTRIBUTING.md 👈🏼 (the "contribution guidelines" up there ☝🏼)

I PROMISE IT'S A VERY VERY SHORT READ.🙇🏼
-->
