### PR TITLE
api documentation tests

### DIFF
--- a/test/docs.js
+++ b/test/docs.js
@@ -1,25 +1,26 @@
 'use strict'
 
-var fs = require('fs')
-var path = require('path')
-var test = require('tap').test
+const BB = require('bluebird')
 
-test('all fixtures are documented', function (t) {
+const fs = BB.promisifyAll(require('fs'))
+const path = require('path')
+const test = require('tap').test
+
+test('all fixtures are documented', t => {
   // TODO - actually parse that table and make sure the
   //        important bits are documented?
   var readmePath = path.join(__dirname, 'fixtures', 'README.md')
-  fs.readFile(readmePath, 'utf8', function (err, text) {
-    if (err) { throw err }
-    fs.readdir(path.dirname(readmePath), function (err, files) {
-      if (err) { throw err }
+  return BB.join(
+    fs.readFileAsync(readmePath, 'utf8'),
+    fs.readdirAsync(path.dirname(readmePath)),
+    (text, files) => {
       files.forEach(function (f) {
         if (f !== 'README.md') {
           t.match(text, f, f + ' is mentioned.')
         }
       })
-      t.end()
-    })
-  })
+    }
+  )
 })
 
 test('all toplevel api calls are documented')

--- a/test/docs.js
+++ b/test/docs.js
@@ -23,4 +23,32 @@ test('all fixtures are documented', t => {
   )
 })
 
-test('all toplevel api calls are documented')
+test('all toplevel api calls are documented', t => {
+  const pacote = require('../')
+  function getFns (obj) {
+    const fns = []
+    for (let k in obj) {
+      if (obj.hasOwnProperty(k) && typeof obj[k] === 'function') {
+        fns.push(k)
+        fns.push.apply(fns, getFns(obj[k], k).map(n => `${k}.${n}`))
+      }
+    }
+    return fns
+  }
+  let apiFns = getFns(pacote)
+  t.comment(apiFns)
+  return fs.readFileAsync(
+    path.join(__dirname, '..', 'README.md'),
+    'utf8'
+  ).then(readme => {
+    apiFns.forEach(fn => {
+      t.match(
+        readme,
+        new RegExp(`#### <a name="[^"]+"></a> \`> pacote.${fn}\\([^)]+\\)\``, 'g'),
+        `pacote.${fn} has a docs entry`
+      )
+    })
+  })
+})
+
+test('all options are documented')


### PR DESCRIPTION
This makes sure that all toplevel api functions have a corresponding entry in README.md. It's a pretty basic test for now, but can be expanded later.

```
# Subtest: all toplevel api calls are documented
    # [ 'extract', 'manifest', 'prefetch' ]
    ok 1 - pacote.extract has a docs entry
    ok 2 - pacote.manifest has a docs entry
    ok 3 - pacote.prefetch has a docs entry
    1..3
ok 2 - all toplevel api calls are documented # time=146.214ms
```