### PR TITLE
feat(scopes): new scopeTargets option

### DIFF
--- a/lib/registry/pick-registry.js
+++ b/lib/registry/pick-registry.js
@@ -2,11 +2,11 @@
 
 module.exports = pickRegistry
 function pickRegistry (spec, opts) {
-  var registry = spec.scope && opts[spec.scope + ':registry']
+  let registry = spec.scope && opts.scopeTargets[spec.scope]
 
   if (!registry && opts.scope) {
-    var prefix = opts.scope[0] === '@' ? '' : '@'
-    registry = opts[prefix + opts.scope + ':registry']
+    const prefix = opts.scope[0] === '@' ? '' : '@'
+    registry = opts.scopeTargets[prefix + opts.scope]
   }
 
   if (!registry) {

--- a/lib/util/opt-check.js
+++ b/lib/util/opt-check.js
@@ -6,6 +6,7 @@ function PacoteOptions (opts) {
   opts = opts || {}
   this._isPacoteOptions = true
   this.auth = opts.auth
+  this.scopeTargets = opts.scopeTargets || {}
   this.defaultTag = opts.defaultTag || 'latest'
   this.cache = opts.cache
   this.cacheUid = opts.cacheUid
@@ -29,12 +30,6 @@ function PacoteOptions (opts) {
   this.dmode = opts.dmode
   this.fmode = opts.fmode
   this.umask = opts.umask
-
-  for (var k in opts) {
-    if (k.match(/:registry$/i)) {
-      this[k] = opts[k]
-    }
-  }
 }
 
 module.exports = optCheck

--- a/test/registry.manifest.js
+++ b/test/registry.manifest.js
@@ -159,7 +159,9 @@ test('treats options as optional', t => {
 
 test('uses scope from spec for registry lookup', t => {
   const opts = {
-    '@myscope:registry': OPTS.registry,
+    scopeTargets: {
+      '@myscope': OPTS.registry
+    },
     // package scope takes priority
     scope: '@otherscope'
   }
@@ -178,7 +180,9 @@ test('uses scope opt for registry lookup', t => {
 
   return BB.join(
     manifest('foo@1.2.3', {
-      '@myscope:registry': OPTS.registry,
+      scopeTargets: {
+        '@myscope': OPTS.registry
+      },
       scope: '@myscope',
       // scope option takes priority
       registry: 'nope'
@@ -186,7 +190,9 @@ test('uses scope opt for registry lookup', t => {
       t.deepEqual(pkg, PKG, 'used scope to pick registry')
     }),
     manifest('bar@latest', {
-      '@myscope:registry': OPTS.registry,
+      scopeTargets: {
+        '@myscope': OPTS.registry
+      },
       scope: 'myscope' // @ auto-inserted
     }).then(pkg => {
       t.deepEqual(pkg, PKG, 'scope @ was auto-inserted')
@@ -207,7 +213,9 @@ test('supports scoped auth', t => {
   const TOKEN = 'deadbeef'
   const opts = {
     scope: 'myscope',
-    '@myscope:registry': OPTS.registry,
+    scopeTargets: {
+      '@myscope': OPTS.registry
+    },
     auth: {
       '//mock.reg/': {
         token: TOKEN


### PR DESCRIPTION
This is a relatively small step as far as having a good
story around auth, but I think at least making it a bit
clearer what these options are and where they come from
is going to be nice.

At least opt-check doesn't have a ton of random @-opts now.
