### PR TITLE
feat(directory): directory dep support

### DIFF
--- a/lib/handlers/directory/manifest.js
+++ b/lib/handlers/directory/manifest.js
@@ -1,0 +1,40 @@
+'use strict'
+
+const BB = require('bluebird')
+
+const glob = BB.promisify(require('glob'))
+const path = require('path')
+
+const readFileAsync = BB.promisify(require('fs').readFile)
+
+module.exports = manifest
+function manifest (spec, opts) {
+  const pkgPath = path.join(spec.spec, 'package.json')
+  const srPath = path.join(spec.spec, 'npm-shrinkwrap.json')
+  return BB.join(
+    readFileAsync(pkgPath).then(JSON.parse),
+    readFileAsync(srPath).then(JSON.parse).catch({code: 'ENOENT'}, () => null),
+    (pkg, sr) => {
+      pkg._shrinkwrap = sr
+      pkg._hasShrinkwrap = !!sr
+      pkg._shasum = 'directory manifests have no shasum'
+      pkg._sha512sum = 'directory manifests have no shasum'
+      return pkg
+    }
+  ).then(pkg => {
+    if (!pkg.bin && pkg.directories && pkg.directories.bin) {
+      const dirBin = pkg.directories.bin
+      return glob(path.join(spec.spec, dirBin, '/**')).then(matches => {
+        matches.forEach(filePath => {
+          const relative = path.relative(dirBin, filePath)
+          if (relative && relative[0] !== '.') {
+            if (!pkg.bin) { pkg.bin = {} }
+            pkg.bin[path.basename(relative)] = path.join(dirBin, relative)
+          }
+        })
+      })
+    } else {
+      return pkg
+    }
+  })
+}

--- a/lib/handlers/directory/tarball.js
+++ b/lib/handlers/directory/tarball.js
@@ -1,0 +1,8 @@
+'use strict'
+
+module.exports = tarballNope
+module.exports.fromManifest = tarballNope
+
+function tarballNope () {
+  throw new Error('local directory packages have no tarball data')
+}

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "cacache": "^6.0.2",
     "checksum-stream": "^1.0.2",
     "dezalgo": "^1.0.3",
+    "glob": "^7.1.1",
     "inflight": "^1.0.6",
     "minimatch": "^3.0.3",
     "mississippi": "^1.2.0",
@@ -58,7 +59,6 @@
     "tar-stream": "^1.5.2"
   },
   "devDependencies": {
-    "glob": "^7.1.1",
     "mkdirp": "^0.5.1",
     "nock": "^9.0.6",
     "npmlog": "^4.0.1",

--- a/test/directory.js
+++ b/test/directory.js
@@ -1,0 +1,59 @@
+'use strict'
+
+const BB = require('bluebird')
+
+const fs = BB.promisifyAll(require('fs'))
+const mkdirp = BB.promisify(require('mkdirp'))
+const path = require('path')
+const test = require('tap').test
+
+const dirManifest = require('../lib/handlers/directory/manifest')
+const dirTarball = require('../lib/handlers/directory/tarball')
+
+const CACHE = require('./util/test-dir')(__filename)
+
+test('supports directory dep manifests', t => {
+  const pkg = {
+    name: 'foo',
+    version: '1.2.3',
+    dependencies: { bar: '3.2.1' },
+    directories: { bin: 'x' },
+    randomProp: 'wut'
+  }
+  const sr = {
+    name: 'foo',
+    version: '1.2.3',
+    isShrinkwrap: true,
+    dependencies: { bar: '3.2.1' }
+  }
+  return mkdirp(path.join(CACHE, 'x')).then(() => {
+    return BB.join(
+      fs.writeFileAsync(
+        path.join(CACHE, 'package.json'), JSON.stringify(pkg)
+      ),
+      fs.writeFileAsync(
+        path.join(CACHE, 'npm-shrinkwrap.json'), JSON.stringify(sr)
+      ),
+      fs.writeFileAsync(
+        path.join(CACHE, 'x', 'mybin'), 'console.log("hi there")'
+      )
+    )
+  }).then(() => {
+    return dirManifest({
+      type: 'directory',
+      spec: CACHE
+    })
+  }).then(manifest => {
+    t.deepEqual(manifest, null, 'got a filled-out manifest')
+  })
+})
+
+test('errors if you try to grab a tarball', t => {
+  return mkdirp(CACHE).then(() => {
+    return dirTarball({type: 'directory', spec: CACHE})
+  }).then(() => {
+    throw new Error('was supposed to fail')
+  }).catch(err => {
+    t.match(err.message, /no tarball/, 'you did a bad thing')
+  })
+})


### PR DESCRIPTION
directory deps are a weird creature -- they require that npm actually go through some lifecycles and such. On top of that, https://github.com/npm/npm/pull/15900 is changing the way directory deps work, to make them symlink.

This PR compromises by letting npm do the heavy lifting on this front. pacote will still be able to read local directory manifests for the CLI, but the CLI will have to do its own linking, do its own filtering so it doesn't ask pacote to extract a directory dep, and, if it wants to use pacote before the new behavior is out, pack its own tarball and then switch to local tarball mode for the rest of the process.
