### PR TITLE
I found a few git things

### DIFF
--- a/lib/handlers/git/manifest.js
+++ b/lib/handlers/git/manifest.js
@@ -3,7 +3,6 @@
 const BB = require('bluebird')
 
 const git = require('../../util/git')
-const normalizeGitUrl = require('normalize-git-url')
 const optCheck = require('../../util/opt-check')
 const pickManifest = require('../../registry/pick-manifest')
 const semver = require('semver')
@@ -36,30 +35,31 @@ function hostedManifest (spec, opts) {
 }
 
 function plainManifest (repo, spec, opts) {
-  const normed = normalizeGitUrl(repo)
-  const rawRef = decodeURIComponent(normed.branch)
+  const rawRef = spec.gitCommittish
   return resolve(
-    normed.url, rawRef, spec.name, opts
+    repo, rawRef, spec.name, opts
   ).then(ref => {
     if (ref) {
+      const resolved = spec.saveSpec.replace(/#.*/, `#${ref.sha}`)
       return {
-        _repo: normed.url,
-        _resolved: `${normed.url}#${ref.sha}`,
+        _repo: repo,
+        _resolved: resolved,
         _spec: spec,
         _ref: ref,
         _rawRef: rawRef,
-        _uniqueResolved: `${normed.url}#${ref.sha}`
+        _uniqueResolved: resolved
       }
     } else {
       // We're SOL and need a full clone :(
       //
       // If we're confident enough that `rawRef` is a commit SHA,
       // then we can at least get `finalize-manifest` to cache its result.
+      const resolved = spec.saveSpec.replace(/#.*/, `#${rawRef}`)
       return {
-        _repo: normed.url,
+        _repo: repo,
         _rawRef: rawRef,
-        _resolved: rawRef.match(/^[a-f0-9]{40}$/) && `${normed.url}#${rawRef}`,
-        _uniqueResolved: rawRef.match(/^[a-f0-9]{40}$/) && `${normed.url}#${rawRef}`
+        _resolved: rawRef.match(/^[a-f0-9]{40}$/) && resolved,
+        _uniqueResolved: rawRef.match(/^[a-f0-9]{40}$/) && resolved
       }
     }
   })

--- a/lib/handlers/git/tarball.js
+++ b/lib/handlers/git/tarball.js
@@ -32,10 +32,11 @@ function fromManifest (manifest, spec, opts) {
   opts = optCheck(opts)
   let streamError
   const stream = new PassThrough().on('error', e => { streamError = e })
+  const cacheName = manifest._resolved || spec.saveSpec || spec.fetchSpec
   const cacheStream = (
     opts.cache &&
     cache.get.stream(
-      opts.cache, cache.key('packed-dir', manifest._resolved), opts
+      opts.cache, cache.key('packed-dir', cacheName), opts
     )
   )
   cacheStream.pipe(stream)
@@ -50,7 +51,11 @@ function fromManifest (manifest, spec, opts) {
           manifest._repo, manifest._ref, manifest._rawRef, tmp, opts
         ).then(HEAD => {
           if (streamError) { throw streamError }
-          return packDir(manifest, manifest._resolved, tmp, stream, opts)
+          if (!manifest._resolved) {
+            manifest._resolved = spec.saveSpec.replace(/#.*/, `#${HEAD}`)
+            manifest._uniqueResolved = manifest._resolved
+          }
+          return packDir(manifest, cacheName, tmp, stream, opts)
         })
       }).catch(err => stream.emit('error', err))
     }

--- a/lib/util/git.js
+++ b/lib/util/git.js
@@ -8,7 +8,6 @@ const execFileAsync = BB.promisify(cp.execFile, {
 })
 const finished = BB.promisify(require('mississippi').finished)
 const LRU = require('lru-cache')
-const normalizeGitUrl = require('normalize-git-url')
 const optCheck = require('./opt-check')
 const osenv = require('osenv')
 const path = require('path')
@@ -51,13 +50,12 @@ try {
 module.exports.clone = fullClone
 function fullClone (repo, committish, target, opts) {
   opts = optCheck(opts)
-  const normed = normalizeGitUrl(repo)
   const gitArgs = [
     'clone',
     '-q',
     // Mainly for windows, but no harm done
     '-c', 'core.longpaths=true',
-    normed.url,
+    repo,
     target
   ]
   return execGit(gitArgs, {
@@ -74,7 +72,6 @@ function fullClone (repo, committish, target, opts) {
 module.exports.shallow = shallowClone
 function shallowClone (repo, branch, target, opts) {
   opts = optCheck(opts)
-  const normed = normalizeGitUrl(repo)
   const gitArgs = [
     'clone',
     '--depth=1',
@@ -82,7 +79,7 @@ function shallowClone (repo, branch, target, opts) {
     '-b', branch,
     // Mainly for windows, but no harm done
     '-c', 'core.longpaths=true',
-    normed.url,
+    repo,
     target
   ]
   return execGit(gitArgs, {

--- a/lib/util/git.js
+++ b/lib/util/git.js
@@ -104,7 +104,7 @@ function updateSubmodules (localRepo, opts) {
 
 function headSha (repo, opts) {
   opts = optCheck(opts)
-  return execGit(['rev-parse', '--revs-only', 'HEAD', repo], {}, opts).spread(stdout => {
+  return execGit(['rev-parse', '--revs-only', 'HEAD'], {cwd: repo}, opts).spread(stdout => {
     return stdout.trim()
   })
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "make-fetch-happen": "^2.2.2",
     "minimatch": "^3.0.3",
     "mississippi": "^1.2.0",
-    "normalize-git-url": "^3.0.2",
     "normalize-package-data": "^2.3.6",
     "npm-package-arg": "^5.0.0",
     "osenv": "^0.1.4",


### PR DESCRIPTION
Well, to start with, I removed `nomralize-git-url` as it wasn't doing much. But while I was doing that, I found two things that were causing issues if you did an install that triggered a full clone:

First, because _resolved wasn't being set, `ca-cache` was using `cache.key('packed-dir', undefined)` as the cache entry.

Second, `_resolved` was never being set with the fully resolved shasum.

Third, `headSha` was returning the shasum for the HEAD of cwd, not the cloned repo.

I tested this using:
```
npm install iarna/emojitime#v1.0.2~
```


