### PR TITLE
feat(extract): add 'safe mode' via extractOverwrite option

### DIFF
--- a/extract.js
+++ b/extract.js
@@ -12,7 +12,7 @@ const rimraf = BB.promisify(require('rimraf'))
 const readdirAsync = BB.promisify(require('fs').readdir)
 
 module.exports = extract
-function extract(spec, dest, opts) {
+function extract (spec, dest, opts) {
   opts = optCheck(opts)
   spec = typeof spec === 'string' ? npa(spec, opts.where) : spec
   const startTime = Date.now()
@@ -63,7 +63,7 @@ function extract(spec, dest, opts) {
 
 }
 
-function extractByDigest(start, spec, dest, opts) {
+function extractByDigest (start, spec, dest, opts) {
   const xtractor = extractStream(dest, opts)
   const cached = cacache.get.stream.byDigest(opts.cache, opts.integrity, opts)
   return pipe(cached, xtractor).then(() => {
@@ -72,7 +72,7 @@ function extractByDigest(start, spec, dest, opts) {
 }
 
 let fetch
-function extractByManifest(start, spec, dest, opts) {
+function extractByManifest (start, spec, dest, opts) {
   const xtractor = extractStream(dest, opts)
   return BB.resolve(null).then(() => {
     if (!fetch) {
@@ -84,14 +84,14 @@ function extractByManifest(start, spec, dest, opts) {
   })
 }
 
-function cleanUpCached(dest, cachePath, integrity, opts) {
+function cleanUpCached (dest, cachePath, integrity, opts) {
   return BB.join(
     rimraf(dest),
     cacache.rm.content(cachePath, integrity, opts)
   )
 }
 
-function checkOverwrite(extractOverwrite, spec, dest) {
+function checkOverwrite (extractOverwrite, spec, dest) {
   return new BB((resolve, reject) => {
     if (!extractOverwrite) {
       readdirAsync(dest)

--- a/extract.js
+++ b/extract.js
@@ -60,7 +60,6 @@ function extract (spec, dest, opts) {
         }, { retries: 1 })
       }
     })
-
 }
 
 function extractByDigest (start, spec, dest, opts) {

--- a/extract.js
+++ b/extract.js
@@ -9,56 +9,61 @@ const pipe = BB.promisify(require('mississippi').pipe)
 const optCheck = require('./lib/util/opt-check')
 const retry = require('promise-retry')
 const rimraf = BB.promisify(require('rimraf'))
+const readdirAsync = BB.promisify(require('fs').readdir)
 
 module.exports = extract
-function extract (spec, dest, opts) {
+function extract(spec, dest, opts) {
   opts = optCheck(opts)
   spec = typeof spec === 'string' ? npa(spec, opts.where) : spec
   const startTime = Date.now()
-  if (opts.integrity && opts.cache && !opts.preferOnline) {
-    opts.log.silly('pacote', 'trying', spec.name, 'by hash:', opts.integrity.toString())
-    return extractByDigest(
-      startTime, spec, dest, opts
-    ).catch(err => {
-      if (err.code === 'ENOENT') {
-        opts.log.silly('pacote', `data for ${opts.integrity} not present. Using manifest.`)
-        return extractByManifest(startTime, spec, dest, opts)
-      }
+  checkOverwrite(opts.extractOverwrite, spec, dest)
+    .then(() => {
+      if (opts.integrity && opts.cache && !opts.preferOnline) {
+        opts.log.silly('pacote', 'trying', spec.name, 'by hash:', opts.integrity.toString())
+        return extractByDigest(
+          startTime, spec, dest, opts
+        ).catch(err => {
+          if (err.code === 'ENOENT') {
+            opts.log.silly('pacote', `data for ${opts.integrity} not present. Using manifest.`)
+            return extractByManifest(startTime, spec, dest, opts)
+          }
 
-      if (err.code === 'EINTEGRITY' || err.code === 'Z_DATA_ERROR') {
-        opts.log.warn('pacote', `cached data for ${spec} (${opts.integrity}) seems to be corrupted. Refreshing cache.`)
-      }
-      return cleanUpCached(
-        dest, opts.cache, opts.integrity, opts
-      ).then(() => {
-        return extractByManifest(startTime, spec, dest, opts)
-      })
-    })
-  } else {
-    opts.log.silly('pacote', 'no tarball hash provided for', spec.name, '- extracting by manifest')
-    return retry((tryAgain, attemptNum) => {
-      return extractByManifest(
-        startTime, spec, dest, opts
-      ).catch(err => {
-        // Retry once if we have a cache, to clear up any weird conditions.
-        // Don't retry network errors, though -- make-fetch-happen has already
-        // taken care of making sure we're all set on that front.
-        if (opts.cache && !err.code.match(/^E\d{3}$/)) {
           if (err.code === 'EINTEGRITY' || err.code === 'Z_DATA_ERROR') {
-            opts.log.warn('pacote', `tarball data for ${spec} (${opts.integrity}) seems to be corrupted. Trying one more time.`)
+            opts.log.warn('pacote', `cached data for ${spec} (${opts.integrity}) seems to be corrupted. Refreshing cache.`)
           }
           return cleanUpCached(
-            dest, opts.cache, err.sri, opts
-          ).then(() => tryAgain(err))
-        } else {
-          throw err
-        }
-      })
-    }, {retries: 1})
-  }
+            dest, opts.cache, opts.integrity, opts
+          ).then(() => {
+            return extractByManifest(startTime, spec, dest, opts)
+          })
+        })
+      } else {
+        opts.log.silly('pacote', 'no tarball hash provided for', spec.name, '- extracting by manifest')
+        return retry((tryAgain, attemptNum) => {
+          return extractByManifest(
+            startTime, spec, dest, opts
+          ).catch(err => {
+            // Retry once if we have a cache, to clear up any weird conditions.
+            // Don't retry network errors, though -- make-fetch-happen has already
+            // taken care of making sure we're all set on that front.
+            if (opts.cache && !err.code.match(/^E\d{3}$/)) {
+              if (err.code === 'EINTEGRITY' || err.code === 'Z_DATA_ERROR') {
+                opts.log.warn('pacote', `tarball data for ${spec} (${opts.integrity}) seems to be corrupted. Trying one more time.`)
+              }
+              return cleanUpCached(
+                dest, opts.cache, err.sri, opts
+              ).then(() => tryAgain(err))
+            } else {
+              throw err
+            }
+          })
+        }, { retries: 1 })
+      }
+    })
+
 }
 
-function extractByDigest (start, spec, dest, opts) {
+function extractByDigest(start, spec, dest, opts) {
   const xtractor = extractStream(dest, opts)
   const cached = cacache.get.stream.byDigest(opts.cache, opts.integrity, opts)
   return pipe(cached, xtractor).then(() => {
@@ -67,7 +72,7 @@ function extractByDigest (start, spec, dest, opts) {
 }
 
 let fetch
-function extractByManifest (start, spec, dest, opts) {
+function extractByManifest(start, spec, dest, opts) {
   const xtractor = extractStream(dest, opts)
   return BB.resolve(null).then(() => {
     if (!fetch) {
@@ -79,9 +84,28 @@ function extractByManifest (start, spec, dest, opts) {
   })
 }
 
-function cleanUpCached (dest, cachePath, integrity, opts) {
+function cleanUpCached(dest, cachePath, integrity, opts) {
   return BB.join(
     rimraf(dest),
     cacache.rm.content(cachePath, integrity, opts)
   )
+}
+
+function checkOverwrite(extractOverwrite, spec, dest) {
+  return new BB((resolve, reject) => {
+    if (!extractOverwrite) {
+      readdirAsync(dest)
+        .then((dir) => {
+          const err = new Error(`Attempted to extract ${spec} to non-empty directory ${dest}. Use the extractOverwrite option to override.`)
+          err.target = dest
+          err.code = 'EBADDIR'
+          reject(err)
+        })
+        .catch({ code: 'ENOENT' }, () => {
+          resolve()
+        })
+    } else {
+      resolve()
+    }
+  })
 }

--- a/lib/util/opt-check.js
+++ b/lib/util/opt-check.js
@@ -37,6 +37,7 @@ function PacoteOptions (opts) {
   this.projectScope = opts.projectScope
   this.fullMetadata = opts.fullMetadata
   this.alwaysAuth = opts.alwaysAuth
+  this.extractOverwrite = opts.extractOverwrite
 
   this.dirPacker = opts.dirPacker || null
 


### PR DESCRIPTION
More or less a WIP, first round without tests. I've never worked with Promises IRL before, my only Promise experience is via API clients on the front-end and my node experience is limited, so I want to know what I did wrong here before digging into tests.

Adds the 'safe mode' outlined in #73, requiring a config option `extractOverwrite` to overwrite an existing directory, otherwise aborting the extract operation

@zkat 