### PR TITLE
fix(registry-key): Use pathname instead of path in registryKey

### DIFF
--- a/lib/fetchers/registry/registry-key.js
+++ b/lib/fetchers/registry/registry-key.js
@@ -9,7 +9,7 @@ function registryKey (registry) {
   const parsed = url.parse(registry)
   const formatted = url.format({
     host: parsed.host,
-    path: parsed.path,
+    pathname: parsed.pathname,
     slashes: parsed.slashes
   })
   return url.resolve(formatted, '.')

--- a/test/registry-key.js
+++ b/test/registry-key.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const tap = require('tap')
+const registryKey = require('../lib/fetchers/registry/registry-key')
+
+tap.equals(registryKey("https://somedomain/somepath/"), "//somedomain/somepath/", "registryKey should keep URL path")
+tap.equals(registryKey("https://somedomain/somepath/morepath"), "//somedomain/somepath/", "registryKey should strip trailing path segment")


### PR DESCRIPTION
Fixes #84