### PR TITLE
fix(git): Resolve to ref git specs w/o committishes

### DIFF
--- a/lib/fetchers/git.js
+++ b/lib/fetchers/git.js
@@ -107,7 +107,7 @@ function plainManifest (repo, spec, opts) {
     repo, rawRef, spec.name, opts
   ).then(ref => {
     if (ref) {
-      const resolved = spec.saveSpec.replace(/#.*/, `#${ref.sha}`)
+      const resolved = spec.saveSpec.replace(/(?:#.*)?$/, `#${ref.sha}`)
       return {
         _repo: repo,
         _resolved: resolved,
@@ -121,7 +121,7 @@ function plainManifest (repo, spec, opts) {
       //
       // If we're confident enough that `rawRef` is a commit SHA,
       // then we can at least get `finalize-manifest` to cache its result.
-      const resolved = spec.saveSpec.replace(/#.*/, `#${rawRef}`)
+      const resolved = spec.saveSpec.replace(/(?:#.*)?$/, `#${rawRef}`)
       return {
         _repo: repo,
         _rawRef: rawRef,


### PR DESCRIPTION
Previously, if your `git` specifier didn't have a `#` in it then the `_resolved` wouldn't include the specific ref we were installing. This changes the behavior to be the same if you have a `#` or if you don't.