### PR TITLE
Add support for global auth and _auth token

### DIFF
--- a/lib/fetchers/registry/fetch.js
+++ b/lib/fetchers/registry/fetch.js
@@ -77,10 +77,13 @@ function getHeaders (uri, registry, opts) {
     'user-agent': opts.userAgent,
     'referer': opts.refer
   }, opts.headers)
-  const auth = (
+  // check for auth settings specific to this registry
+  let auth = (
     opts.auth &&
     opts.auth[registryKey(registry)]
   )
+  // if no specifics, check for globals
+  if (!auth && opts.auth && opts.auth.alwaysAuth) { auth = opts.auth}
   // If a tarball is hosted on a different place than the manifest, only send
   // credentials on `alwaysAuth`
   const shouldAuth = auth && (
@@ -94,6 +97,8 @@ function getHeaders (uri, registry, opts) {
       `${auth.username}:${auth.password}`, 'utf8'
     ).toString('base64')
     headers.authorization = `Basic ${encoded}`
+  } else if (shouldAuth && auth._auth) {
+    headers.authorization = `Basic ${auth._auth}`
   }
   return headers
 }

--- a/test/registry.manifest.js
+++ b/test/registry.manifest.js
@@ -234,6 +234,48 @@ test('supports scoped auth', t => {
   })
 })
 
+test('sends auth token if passed in global opts', t => {
+  const TOKEN = 'deadbeef'
+  const opts = {
+    registry: OPTS.registry,
+    auth: {
+      alwaysAuth: true,
+      token: TOKEN
+    }
+  }
+
+  const srv = tnock(t, OPTS.registry)
+  srv.get(
+    '/foo'
+  ).matchHeader(
+    'authorization', 'Bearer ' + TOKEN
+  ).reply(200, META)
+  return manifest('foo@1.2.3', opts).then(pkg => {
+    t.deepEqual(pkg, PKG, 'got manifest from version')
+  })
+})
+
+test('sends basic authorization if alwaysAuth and _auth', t => {
+  const TOKEN = 'deadbeef'
+  const opts = {
+    registry: OPTS.registry,
+    auth: {
+      alwaysAuth: true,
+      _auth: TOKEN
+    }
+  }
+
+  const srv = tnock(t, OPTS.registry)
+  srv.get(
+    '/foo'
+  ).matchHeader(
+    'authorization', 'Basic ' + TOKEN
+  ).reply(200, META)
+  return manifest('foo@1.2.3', opts).then(pkg => {
+    t.deepEqual(pkg, PKG, 'got manifest from version')
+  })
+})
+
 test('package requests are case-sensitive', t => {
   const srv = tnock(t, OPTS.registry)
 


### PR DESCRIPTION
Fixes: #16528

Pacote supported only scoped auth and dropped support for _auth alltogether. I added both and two tests to verify.