### PR TITLE
util/git: limit ls-remote output to heads/tags

### DIFF
--- a/lib/util/git.js
+++ b/lib/util/git.js
@@ -105,7 +105,7 @@ function revs (repo, opts) {
     return BB.resolve(cached)
   }
   return pinflight(`ls-remote:${repo}`, () => {
-    return spawnGit(['ls-remote', repo], {
+    return spawnGit(['ls-remote', '-h', '-t', repo], {
       env: gitEnv()
     }, opts).then(child => {
       let stdout = ''


### PR DESCRIPTION
GitHub repositories can contain other types of refs, such as pull requests, which can be fetched via `git-fetch` but not cloned via `git clone -b`.

Fixes npm/npm#16898.

<!--
⚠️🚨 BEFORE FILING A PR: 🚨⚠️

👉🏼 CONTRIBUTING.md 👈🏼 (the "contribution guidelines" up there ☝🏼)

I PROMISE IT'S A VERY VERY SHORT READ.🙇🏼
-->
