### PR TITLE
[wip] Fallback to remoteRefs if pickManifest fails

### DIFF
--- a/lib/fetchers/git.js
+++ b/lib/fetchers/git.js
@@ -132,18 +132,32 @@ function plainManifest (repo, spec, opts) {
 function resolve (url, spec, name, opts) {
   const isSemver = !!spec.gitRange
   return git.revs(url, opts).then(remoteRefs => {
-    return isSemver
-    ? pickManifest({
+    if (isSemver) {
+      return resolveSemverRef(remoteRefs, spec, name);
+    } else {
+      return resolveRemoteRef(remoteRefs, spec);
+    }
+  })
+}
+
+function resolveSemverRef(remoteRefs, spec, name) {
+  try {
+    return pickManifest({
       versions: remoteRefs.versions,
       'dist-tags': remoteRefs['dist-tags'],
       name: name
     }, spec.gitRange, opts)
-    : remoteRefs
-    ? BB.resolve(
-      remoteRefs.refs[spec.gitCommittish] || remoteRefs.refs[remoteRefs.shas[spec.gitCommittish]]
-    )
-    : null
-  })
+  } catch (err) {
+    return resolveRemoteRef(remoteRefs, spec);
+  }
+}
+
+function resolveRemoteRef(remoteRefs, spec) {
+  return remoteRefs
+  ? BB.resolve(
+    remoteRefs.refs[spec.gitCommittish] || remoteRefs.refs[remoteRefs.shas[spec.gitCommittish]]
+  )
+  : null;
 }
 
 function withTmp (opts, cb) {


### PR DESCRIPTION
It's possible for a git repository to have semver like branches/tags.
For semver like refs, also check remoteRefs if pickManifest fails.