### PR TITLE
Add API for fetching packuments

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,27 @@ pacote.manifest('pacote@1.0.0').then(pkgJson => {
 })
 ```
 
+#### <a name="packument"></a> `> pacote.packument(spec, [opts])`
+
+Fetches the *packument* for a package. Packument objects are collections of
+manifests where each one represents a different version of a package.
+
+```javascript
+{
+  "name": PkgName,
+  "dist-tags": { TagName: PkgVersion },
+  "versions": { PkgVersion: PkgManifest }
+}
+```
+
+##### Example
+
+```javascript
+pacote.packument('pacote').then(packument => {
+  // do some work with `packument`
+})
+```
+
 #### <a name="extract"></a> `> pacote.extract(spec, destination, [opts])`
 
 Extracts package data identified by `<spec>` into a directory named

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 module.exports = {
   extract: require('./extract'),
   manifest: require('./manifest'),
+  packument: require('./packument'),
   prefetch: require('./prefetch'),
   clearMemoized: require('./lib/fetch').clearMemoized
 }

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -4,6 +4,7 @@ const duck = require('protoduck')
 
 const Fetcher = duck.define(['spec', 'opts', 'manifest'], {
   manifest: ['spec', 'opts'],
+  packument: ['spec', 'opts'],
   tarball: ['spec', 'opts'],
   fromManifest: ['manifest', 'spec', 'opts'],
   clearMemoized () {}
@@ -14,6 +15,12 @@ module.exports.manifest = manifest
 function manifest (spec, opts) {
   const fetcher = getFetcher(spec.type)
   return fetcher.manifest(spec, opts)
+}
+
+module.exports.packument = packument
+function packument (spec, opts) {
+  const fetcher = getFetcher(spec.type)
+  return fetcher.packument(spec, opts)
 }
 
 module.exports.tarball = tarball

--- a/lib/fetchers/directory.js
+++ b/lib/fetchers/directory.js
@@ -49,6 +49,11 @@ Fetcher.impl(fetchDirectory, {
     })
   },
 
+  packument (spec, opts) {
+    // We'll be handled by finalizePackument.
+    return BB.resolve(null)
+  },
+
   // As of npm@5, the npm installer doesn't pack + install directories: it just
   // creates symlinks. This code is here because `npm pack` still needs the
   // ability to create a tarball from a local directory.

--- a/lib/fetchers/file.js
+++ b/lib/fetchers/file.js
@@ -22,6 +22,11 @@ Fetcher.impl(fetchFile, {
     return BB.resolve(null)
   },
 
+  packument (spec, opts) {
+    // We'll be handled by finalizePackument.
+    return BB.resolve(null)
+  },
+
   // All the heavy lifting for `file` packages is done here.
   // They're never cached. We just read straight out of the file.
   // TODO - maybe they *should* be cached?

--- a/lib/fetchers/git.js
+++ b/lib/fetchers/git.js
@@ -31,6 +31,11 @@ Fetcher.impl(fetchGit, {
     }
   },
 
+  packument (spec, opts) {
+    // We'll be handled by finalizePackument.
+    return BB.resolve(null)
+  },
+
   tarball (spec, opts) {
     opts = optCheck(opts)
     const stream = new PassThrough()

--- a/lib/fetchers/registry/index.js
+++ b/lib/fetchers/registry/index.js
@@ -3,6 +3,7 @@
 const cacache = require('cacache')
 const Fetcher = require('../../fetch')
 const regManifest = require('./manifest')
+const regPackument = require('./packument')
 const regTarball = require('./tarball')
 
 const fetchRegistry = module.exports = Object.create(null)
@@ -10,6 +11,10 @@ const fetchRegistry = module.exports = Object.create(null)
 Fetcher.impl(fetchRegistry, {
   manifest (spec, opts) {
     return regManifest(spec, opts)
+  },
+
+  packument (spec, opts) {
+    return regPackument(spec, opts)
   },
 
   tarball (spec, opts) {
@@ -22,6 +27,6 @@ Fetcher.impl(fetchRegistry, {
 
   clearMemoized () {
     cacache.clearMemoized()
-    regManifest.clearMemoized()
+    regPackument.clearMemoized()
   }
 })

--- a/lib/fetchers/registry/manifest.js
+++ b/lib/fetchers/registry/manifest.js
@@ -36,7 +36,7 @@ function getManifest (uri, registry, spec, opts) {
         )
         opts.preferOffline = false
         opts.preferOnline = true
-        return fetchPackument(uri, egistry, spec, opts).then(packument => {
+        return fetchPackument(uri, registry, spec, opts).then(packument => {
           return pickManifest(packument, spec.fetchSpec, {
             defaultTag: opts.defaultTag
           })

--- a/lib/fetchers/registry/manifest.js
+++ b/lib/fetchers/registry/manifest.js
@@ -3,16 +3,12 @@
 const BB = require('bluebird')
 
 const fetch = require('./fetch')
-const LRU = require('lru-cache')
 const optCheck = require('../../util/opt-check')
 const pickManifest = require('npm-pick-manifest')
 const pickRegistry = require('./pick-registry')
 const ssri = require('ssri')
-const url = require('url')
-
-// Corgis are cute. 🐕🐶
-const CORGI_DOC = 'application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*'
-const JSON_DOC = 'application/json'
+const metadataUrl = require('./metadata-url')
+const fetchPackument = require('./packument').fetchPackument
 
 module.exports = manifest
 function manifest (spec, opts) {
@@ -26,15 +22,8 @@ function manifest (spec, opts) {
   })
 }
 
-function metadataUrl (registry, name) {
-  const normalized = registry.slice(-1) !== '/'
-  ? registry + '/'
-  : registry
-  return url.resolve(normalized, name)
-}
-
 function getManifest (uri, registry, spec, opts) {
-  return fetchPackument(uri, spec, registry, opts).then(packument => {
+  return fetchPackument(uri, registry, spec, opts).then(packument => {
     try {
       return pickManifest(packument, spec.fetchSpec, {
         defaultTag: opts.defaultTag
@@ -47,7 +36,7 @@ function getManifest (uri, registry, spec, opts) {
         )
         opts.preferOffline = false
         opts.preferOnline = true
-        return fetchPackument(uri, spec, registry, opts).then(packument => {
+        return fetchPackument(uri, egistry, spec, opts).then(packument => {
           return pickManifest(packument, spec.fetchSpec, {
             defaultTag: opts.defaultTag
           })
@@ -57,68 +46,6 @@ function getManifest (uri, registry, spec, opts) {
       }
     }
   })
-}
-
-// TODO - make this an opt
-const MEMO = new LRU({
-  length: m => m._contentLength,
-  max: 200 * 1024 * 1024, // 200MB
-  maxAge: 30 * 1000 // 30s
-})
-
-module.exports.clearMemoized = clearMemoized
-function clearMemoized () {
-  MEMO.reset()
-}
-
-function fetchPackument (uri, spec, registry, opts) {
-  const mem = pickMem(opts)
-  if (mem && !opts.preferOnline && mem.has(uri)) {
-    return BB.resolve(mem.get(uri))
-  }
-
-  return fetch(uri, registry, Object.assign({
-    headers: {
-      'pacote-req-type': 'packument',
-      'pacote-pkg-id': `registry:${manifest.name}`,
-      accept: opts.fullMetadata ? JSON_DOC : CORGI_DOC
-    },
-    spec
-  }, opts, {
-    // Force integrity to null: we never check integrity hashes for manifests
-    integrity: null
-  })).then(res => res.json().then(packument => {
-    packument._cached = decodeURIComponent(res.headers.has('x-local-cache'))
-    packument._contentLength = +res.headers.get('content-length')
-    // NOTE - we need to call pickMem again because proxy
-    //        objects get reused!
-    const mem = pickMem(opts)
-    if (mem) {
-      mem.set(uri, packument)
-    }
-    return packument
-  }))
-}
-
-class ObjProxy {
-  get (key) { return this.obj[key] }
-  set (key, val) { this.obj[key] = val }
-}
-
-// This object is used synchronously and immediately, so
-// we can safely reuse it instead of consing up new ones
-const PROX = new ObjProxy()
-function pickMem (opts) {
-  if (!opts || !opts.memoize) {
-    return MEMO
-  } else if (opts.memoize.get && opts.memoize.set) {
-    return opts.memoize
-  } else if (typeof opts.memoize === 'object') {
-    PROX.obj = opts.memoize
-    return PROX
-  } else {
-    return null
-  }
 }
 
 function annotateManifest (uri, registry, manifest) {

--- a/lib/fetchers/registry/metadata-url.js
+++ b/lib/fetchers/registry/metadata-url.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const url = require('url')
+
+module.exports = metadataUrl
+function metadataUrl (registry, name) {
+  const normalized = registry.slice(-1) !== '/'
+  ? registry + '/'
+  : registry
+  return url.resolve(normalized, name)
+}
+

--- a/lib/fetchers/registry/packument.js
+++ b/lib/fetchers/registry/packument.js
@@ -1,0 +1,88 @@
+'use strict'
+
+const BB = require('bluebird')
+
+const fetch = require('./fetch')
+const LRU = require('lru-cache')
+const optCheck = require('../../util/opt-check')
+const pickRegistry = require('./pick-registry')
+const metadataUrl = require('./metadata-url')
+const ssri = require('ssri')
+
+// Corgis are super cute. 🐕🐶
+const CORGI_DOC = 'application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*'
+const JSON_DOC = 'application/json'
+
+module.exports = packument;
+function packument (spec, opts) {
+  opts = optCheck(opts)
+
+  const registry = pickRegistry(spec, opts)
+  const uri = metadataUrl(registry, spec.escapedName)
+
+  return fetchPackument(uri, registry, spec, opts)
+}
+
+module.exports.fetchPackument = fetchPackument
+function fetchPackument (uri, registry, spec, opts) {
+  const mem = pickMem(opts)
+  if (mem && !opts.preferOnline && mem.has(uri)) {
+    return BB.resolve(mem.get(uri))
+  }
+
+  return fetch(uri, registry, Object.assign({
+    headers: {
+      'pacote-req-type': 'packument',
+      'pacote-pkg-id': `registry:${spec.name}`,
+      accept: opts.fullMetadata ? JSON_DOC : CORGI_DOC
+    },
+    spec
+  }, opts, {
+    // Force integrity to null: we never check integrity hashes for manifests
+    integrity: null
+  })).then(res => res.json().then(packument => {
+    packument._cached = decodeURIComponent(res.headers.has('x-local-cache'))
+    packument._contentLength = +res.headers.get('content-length')
+    // NOTE - we need to call pickMem again because proxy
+    //        objects get reused!
+    const mem = pickMem(opts)
+    if (mem) {
+      mem.set(uri, packument)
+    }
+    return packument
+  }))
+}
+
+// TODO - make this an opt
+const MEMO = new LRU({
+  length: m => m._contentLength,
+  max: 200 * 1024 * 1024, // 200MB
+  maxAge: 30 * 1000 // 30s
+})
+
+module.exports.clearMemoized = clearMemoized
+function clearMemoized () {
+  MEMO.reset()
+}
+
+class ObjProxy {
+  get (key) { return this.obj[key] }
+  set (key, val) { this.obj[key] = val }
+}
+
+// This object is used synchronously and immediately, so
+// we can safely reuse it instead of consing up new ones
+const PROX = new ObjProxy()
+function pickMem (opts) {
+  if (!opts || !opts.memoize) {
+    return MEMO
+  } else if (opts.memoize.get && opts.memoize.set) {
+    return opts.memoize
+  } else if (typeof opts.memoize === 'object') {
+    PROX.obj = opts.memoize
+    return PROX
+  } else {
+    return null
+  }
+}
+

--- a/lib/fetchers/remote.js
+++ b/lib/fetchers/remote.js
@@ -16,6 +16,11 @@ Fetcher.impl(fetchRemote, {
     return BB.resolve(null)
   },
 
+  packument (spec, opts) {
+    // We'll be handled by finalizePackument.
+    return BB.resolve(null)
+  },
+
   tarball (spec, opts) {
     const uri = spec._resolved || spec.fetchSpec
     return fetchRegistry.fromManifest({

--- a/packument.js
+++ b/packument.js
@@ -1,0 +1,50 @@
+'use strict'
+
+const fetchPackument = require('./lib/fetch').packument
+const optCheck = require('./lib/util/opt-check')
+const pinflight = require('promise-inflight')
+const npa = require('npm-package-arg')
+const manifest = require('./manifest')
+
+module.exports = packument
+function packument (spec, opts) {
+  opts = optCheck(opts)
+  spec = typeof spec === 'string' ? npa(spec, opts.where) : spec
+
+  const label = [
+    spec.name,
+    spec.saveSpec || spec.fetchSpec,
+    spec.type,
+    opts.cache,
+    opts.registry,
+    opts.scope
+  ].join(':')
+  return pinflight(label, () => {
+    const startTime = Date.now()
+    return fetchPackument(spec, opts).then(packument => {
+      return finalizePackument(packument, spec, opts)
+    }).then(packument => {
+      const elapsedTime = Date.now() - startTime
+      opts.log.silly('pacote', `${spec.type} manifest for ${spec.name}@${spec.saveSpec || spec.fetchSpec} fetched in ${elapsedTime}ms`)
+      return packument
+    })
+  })
+}
+
+function finalizePackument (packument, spec, opts) {
+  if (packument == null) {
+    // Some fetchers may opt out of returning packument documents as they can't
+    // produce meaningful results (packages referred by URL, tarballs). In that
+    // case we fetch the corresponding manifest and create a packument out of
+    // it.
+    return manifest(spec, opts).then(manifest => {
+      return {
+        name: manifest.name,
+        'dist-tags': {},
+        versions: {[manifest.version]: manifest}
+      }
+    })
+  } else {
+    return packument
+  }
+}


### PR DESCRIPTION
**WIP: DO NOT MERGE YET BUT PLEASE PROVIDE FEEDBACK**

As discussed on package.community Discord I've added an API for fetching packuments.

Currently:
* Registry fetcher fetches the actual packument.
* All other fetchers just return `null` which indicates that `finalizePackument` routine should fetch the corresponding manifest for the package spec and synthesise a packument out of it.

Tests are failing for me for some reason (can't really see what's wrong yet). If you are fine with the approach proposed — I'll fix the test suite and add more tests specifically for the packument API.

It's better to review a commit by commit.