### PR TITLE
Bug - Pass maxSockets down to make-fetch-happen

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ directly for matching contents before performing any other operations.
 ##### `opts.@somescope:registry`
 ##### `opts.auth`
 ##### `opts.log`
+##### `opts.maxSockets`
 
 Default: `silentNpmLog`
 

--- a/lib/fetchers/registry/fetch.js
+++ b/lib/fetchers/registry/fetch.js
@@ -22,6 +22,7 @@ function regFetch (uri, registry, opts) {
     integrity: opts.integrity,
     key: opts.key,
     localAddress: opts.localAddress,
+    maxSockets: opts.maxSockets,
     memoize: opts.memoize,
     noProxy: opts.noProxy,
     Promise: BB,


### PR DESCRIPTION
Fixes #109
This allows for maxSockets option to be passed down by npm to make-fetch-happen so it could limit the number of connections being used as certain "enterprise grade" proxies fall over if you 
open too many connections.

This is not a global setting and so if multiple requests are made then will each be individually limited to the number of connections but the total number used by all could exceed that value.

Not sure if I should have made the `README.md` change as I can see a lot of the other options are not documented here.