### PR TITLE
perf(extract): speed up extract functions

### DIFF
--- a/lib/extract-stream.js
+++ b/lib/extract-stream.js
@@ -9,15 +9,18 @@ function extractStream (dest, opts) {
   const sawIgnores = new Set()
   return tar.x({
     cwd: dest,
-    filter: (name, entry) => !entry.header.type.match(/^.*link$/i),
+    // Use endsWith rather than match with regex. Should be faster.
+    filter: (name, entry) => !entry.header.type.endsWith('link'),
     strip: 1,
     onwarn: msg => opts.log && opts.log.warn('tar', msg),
     uid: opts.uid,
     gid: opts.gid,
     onentry (entry) {
-      if (entry.type.toLowerCase() === 'file') {
+      // Only lowerCase once.
+      const entryType = entry.type.toLowerCase()
+      if (entryType === 'file') {
         entry.mode = opts.fmode & ~(opts.umask || 0)
-      } else if (entry.type.toLowerCase() === 'directory') {
+      } else if (entryType === 'directory') {
         entry.mode = opts.dmode & ~(opts.umask || 0)
       }
 
@@ -25,12 +28,14 @@ function extractStream (dest, opts) {
       // employed during tarball creation, in the fstream-npm module.
       // It is duplicated here to handle tarballs that are created
       // using other means, such as system tar or git archive.
-      if (entry.type.toLowerCase() === 'file') {
+      if (entryType === 'file') {
         const base = path.basename(entry.path)
         if (base === '.npmignore') {
           sawIgnores.add(entry.path)
         } else if (base === '.gitignore') {
-          const npmignore = entry.path.replace(/\.gitignore$/, '.npmignore')
+          // Cut off last 10 chars (.gitignore) and replace with .npmignore.
+          // substring should be faster than regex.
+          const npmignore = entry.path.slice(0, -10) + '.npmignore'
           if (!sawIgnores.has(npmignore)) {
             // Rename, may be clobbered later.
             entry.path = npmignore


### PR DESCRIPTION
while these are minimal changes, repeating each one for every entry in a tar file should provide improved speed for larger, or many, tarballs.
only lowercase once, to save precious cycles.
replace regex with plain string functions because regex can be slower.
