### PR TITLE
Move error handling into git child process helpers

### DIFF
--- a/lib/util/git.js
+++ b/lib/util/git.js
@@ -3,9 +3,6 @@
 const BB = require('bluebird')
 
 const cp = require('child_process')
-const execFileAsync = BB.promisify(cp.execFile, {
-  multiArgs: true
-})
 const finished = BB.promisify(require('mississippi').finished)
 const LRU = require('lru-cache')
 const optCheck = require('./opt-check')
@@ -107,15 +104,7 @@ function revs (repo, opts) {
   return pinflight(`ls-remote:${repo}`, () => {
     return spawnGit(['ls-remote', '-h', '-t', repo], {
       env: gitEnv()
-    }, opts).then(child => {
-      let stdout = ''
-      let stderr = ''
-      child.stdout.on('data', d => { stdout += d })
-      child.stderr.on('data', d => { stderr += d })
-      return finished(child).catch(err => {
-        err.message = `Error while executing:\n${GITPATH} ls-remote -h -t ${repo}\n\n${stderr}\n${err.message}`
-        throw err
-      }).then(() => {
+    }, opts).then(stdout => {
         return stdout.split('\n').reduce((revs, line) => {
           const split = line.split(/\s+/, 2)
           if (split.length < 2) { return revs }
@@ -159,14 +148,21 @@ function revs (repo, opts) {
         return revs
       })
     })
-  })
 }
 
 module.exports._exec = execGit
 function execGit (gitArgs, gitOpts, opts) {
   opts = optCheck(opts)
   return checkGit().then(gitPath => {
-    return execFileAsync(gitPath, gitArgs, mkOpts(gitOpts, opts))
+    return new Promise((resolve, reject) => {
+      cp.execFile(gitPath, gitArgs, mkOpts(gitOpts, opts), (err, stdout, stderr) => {
+        if (err) {
+          err.message = `Error while executing:\n${gitPath} ${gitArgs.join(' ')}\n\n${stderr}\n${err.message}`
+          return reject(err)
+        }
+        return resolve([stdout, stderr])
+      })
+    })
   })
 }
 
@@ -174,7 +170,17 @@ module.exports._spawn = spawnGit
 function spawnGit (gitArgs, gitOpts, opts) {
   opts = optCheck(opts)
   return checkGit().then(gitPath => {
-    return cp.spawn(gitPath, gitArgs, mkOpts(gitOpts, opts))
+    const child = cp.spawn(gitPath, gitArgs, mkOpts(gitOpts, opts))
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', d => { stdout += d })
+    child.stderr.on('data', d => { stderr += d })
+    return finished(child)
+      .then(() => stdout)
+      .catch(err => {
+        err.message = `Error while executing:\n${gitPath} ${gitArgs.join(' ')}\n\n${stderr}\n${err.message}`
+        throw err
+      })
   })
 }
 


### PR DESCRIPTION
<!--
⚠️🚨 BEFORE FILING A PR: 🚨⚠️

👉🏼 CONTRIBUTING.md 👈🏼 (the "contribution guidelines" up there ☝🏼)

I PROMISE IT'S A VERY VERY SHORT READ.🙇🏼
-->

Moved the one-off error handling from the `revs` function into the two `child-process` git helper functions. Because of the way `execFile` works, had to un-promisify it and build the promise manually, so that `stderr` was available in the error handling.

Example output of misspelled git command:

```
npm ERR! code 1
npm ERR! Error while executing:
npm ERR! /usr/bin/git clon -q git://github.com/scotttrinh/pacote.git /home/strinh/.npm/_cacache/tmp/git-clone-cf6328cf
npm ERR!
npm ERR! git: 'clon' is not a git command. See 'git --help'.
npm ERR!
npm ERR! Did you mean one of these?
npm ERR!        clone
npm ERR!        column
npm ERR!
npm ERR! Command failed: /usr/bin/git clon -q git://github.com/scotttrinh/pacote.git /home/strinh/.npm/_cacache/tmp/git-clone-cf6328cf
npm ERR! git: 'clon' is not a git command. See 'git --help'.
npm ERR!
npm ERR! Did you mean one of these?
npm ERR!        clone
npm ERR!        column
npm ERR!

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/strinh/.npm/_logs/2017-08-30T12_07_56_138Z-debug.log
```

Seems that the `err.message` already contains `stderr` (at least in these cases), but I didn't want to change the formula you used for `revs` since I'm sure they're there for a reason. Let me know if you'd prefer that I drop the extra `\n\n${err.message}`.

Closes #92 