### PR TITLE
fix(extract): preserve executable perms on extracted files

### DIFF
--- a/lib/extract-stream.js
+++ b/lib/extract-stream.js
@@ -15,11 +15,10 @@ function extractStream (dest, opts) {
     uid: opts.uid,
     gid: opts.gid,
     onentry (entry) {
-      if (entry.type.toLowerCase() === 'file') {
-        entry.mode = opts.fmode & ~(opts.umask || 0)
-      } else if (entry.type.toLowerCase() === 'directory') {
-        entry.mode = opts.dmode & ~(opts.umask || 0)
-      }
+      entry.mode = entry.mode | (
+        entry.type.toLowerCase() === 'directory' ? opts.dmode : opts.fmode
+      )
+      entry.mode = entry.mode & (~opts.umask || 0)
 
       // Note: This mirrors logic in the fs read operations that are
       // employed during tarball creation, in the fstream-npm module.

--- a/test/extract-stream.chown.js
+++ b/test/extract-stream.chown.js
@@ -54,11 +54,11 @@ test('accepts gid and uid opts', {skip: !process.getuid}, t => {
       log: npmlog
     }))
   }).then(() => {
-    t.deepEqual(updatedPaths, [
+    t.deepEqual(updatedPaths.sort(), [
       'target',
       'target/foo',
       'target/package.json',
       'target/foo/index.js'
-    ], 'extracted files had correct uid/gid set')
+    ].sort(), 'extracted files had correct uid/gid set')
   })
 })


### PR DESCRIPTION
This is basically a copy-paste from the old way npm
would set permissions on extract, and should now be
fully compatible again. I hope. Sigh.

<!--
⚠️🚨 BEFORE FILING A PR: 🚨⚠️

👉🏼 CONTRIBUTING.md 👈🏼 (the "contribution guidelines" up there ☝🏼)

I PROMISE IT'S A VERY VERY SHORT READ.🙇🏼
-->
