### PR TITLE
feat(selection): add opts.includeDeprecated

### DIFF
--- a/lib/fetchers/registry/manifest.js
+++ b/lib/fetchers/registry/manifest.js
@@ -37,7 +37,8 @@ function getManifest (uri, registry, spec, opts) {
   return fetchPackument(uri, spec, registry, opts).then(packument => {
     try {
       return pickManifest(packument, spec.fetchSpec, {
-        defaultTag: opts.defaultTag
+        defaultTag: opts.defaultTag,
+        includeDeprecated: opts.includeDeprecated
       })
     } catch (err) {
       if (err.code === 'ETARGET' && packument._cached && !opts.offline) {

--- a/lib/util/opt-check.js
+++ b/lib/util/opt-check.js
@@ -43,6 +43,9 @@ function PacoteOptions (opts) {
   this.projectScope = opts.projectScope
   this.fullMetadata = opts.fullMetadata
   this.alwaysAuth = opts.alwaysAuth
+  this.includeDeprecated = opts.includeDeprecated == null
+  ? true
+  : opts.includeDeprecated
 
   this.dirPacker = opts.dirPacker || null
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2596,25 +2596,12 @@
       }
     },
     "npm-pick-manifest": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-1.0.4.tgz",
-      "integrity": "sha512-MKxNdeyOZysPRTTbHtW0M5Fw38Jo/3ARsoGw5qjCfS+XGjvNB/Gb4qtAZUFmKPM2mVum+eX559eHvKywU856BQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-2.1.0.tgz",
+      "integrity": "sha512-q9zLP8cTr8xKPmMZN3naxp1k/NxVFsjxN6uWuO1tiw9gxg7wZWQ/b5UTfzD0ANw2q1lQxdLKTeCCksq+bPSgbQ==",
       "requires": {
-        "npm-package-arg": "5.1.2",
+        "npm-package-arg": "6.0.0",
         "semver": "5.4.1"
-      },
-      "dependencies": {
-        "npm-package-arg": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-5.1.2.tgz",
-          "integrity": "sha512-wJBsrf0qpypPT7A0LART18hCdyhpCMxeTtcb0X4IZO2jsP6Om7EHN1d9KSKiqD+KVH030RVNpWS9thk+pb7wzA==",
-          "requires": {
-            "hosted-git-info": "2.4.2",
-            "osenv": "0.1.4",
-            "semver": "5.4.1",
-            "validate-npm-package-name": "3.0.0"
-          }
-        }
       }
     },
     "npm-run-path": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "normalize-package-data": "^2.4.0",
     "npm-package-arg": "^6.0.0",
     "npm-packlist": "^1.1.9",
-    "npm-pick-manifest": "^1.0.4",
+    "npm-pick-manifest": "^2.1.0",
     "osenv": "^0.1.4",
     "promise-inflight": "^1.0.1",
     "promise-retry": "^1.1.1",

--- a/test/registry.manifest.js
+++ b/test/registry.manifest.js
@@ -40,7 +40,26 @@ const META = {
     },
     '2.0.4': {
       name: 'foo',
-      version: '2.0.4'
+      version: '2.0.4',
+      _hasShrinkwrap: false,
+      _integrity: 'sha1-deadbeef',
+      _resolved: 'https://foo.bar/x.tgz',
+      dist: {
+        integrity: 'sha1-deadbeef',
+        tarball: 'https://foo.bar/x.tgz'
+      }
+    },
+    '2.0.5': {
+      name: 'foo',
+      version: '2.0.5',
+      deprecated: 'yes. yes it is.',
+      _hasShrinkwrap: false,
+      _integrity: 'sha1-deadbeef',
+      _resolved: 'https://foo.bar/x.tgz',
+      dist: {
+        integrity: 'sha1-deadbeef',
+        tarball: 'https://foo.bar/x.tgz'
+      }
     },
     '1.2.1': {
       name: 'foo',
@@ -123,6 +142,20 @@ test('fetches manifest from scoped registry by range', t => {
   srv.get('/@usr%2ffoo').reply(200, META)
   return manifest('@usr/foo@^1.2.0', OPTS).then(pkg => {
     t.deepEqual(pkg, new Manifest(META.versions['1.2.3']), 'got scoped manifest from version')
+  })
+})
+
+test('supports opts.includeDeprecated', t => {
+  const srv = tnock(t, OPTS.registry)
+
+  srv.get('/foo').reply(200, META)
+  return manifest('foo@^2', OPTS).then(pkg => {
+    t.deepEqual(pkg, new Manifest(META.versions['2.0.5']), 'got deprecated')
+    return manifest('foo@^2.0', Object.assign({
+      includeDeprecated: false
+    }, OPTS))
+  }).then(pkg => {
+    t.deepEqual(pkg, new Manifest(META.versions['2.0.4']), 'non-deprecated')
   })
 })
 


### PR DESCRIPTION
This is mainly so we can keep using the latest npm-pick-manifest,
which previously included deprecation-skipping as a breaking change.

With this patch, we can flip a switch for the semver-major change on
the npm side of things whenever, and the api for pacote will remain
the same unless the flag is passed in explicitly.

<!--
⚠️🚨 BEFORE FILING A PR: 🚨⚠️

👉🏼 CONTRIBUTING.md 👈🏼 (the "contribution guidelines" up there ☝🏼)

I PROMISE IT'S A VERY VERY SHORT READ.🙇🏼
-->
