### PR TITLE
fix(git): use resolved ref if available when doing a full clone

### DIFF
--- a/lib/fetchers/git.js
+++ b/lib/fetchers/git.js
@@ -163,8 +163,8 @@ const SHALLOW_HOSTS = new Set(['github', 'gist', 'gitlab', 'bitbucket'])
 function cloneRepo (spec, repo, resolvedRef, rawRef, tmp, opts) {
   const ref = resolvedRef ? resolvedRef.ref : rawRef
   if (spec.hosted && SHALLOW_HOSTS.has(spec.hosted.type)) {
-      return git.shallow(repo, ref, tmp, opts)
+    return git.shallow(repo, ref, tmp, opts)
   } else {
-      return git.clone(repo, ref, tmp, opts)
+    return git.clone(repo, ref, tmp, opts)
   }
 }

--- a/lib/fetchers/git.js
+++ b/lib/fetchers/git.js
@@ -161,9 +161,10 @@ function withTmp (opts, cb) {
 // Only certain whitelisted hosted gits support shadow cloning
 const SHALLOW_HOSTS = new Set(['github', 'gist', 'gitlab', 'bitbucket'])
 function cloneRepo (spec, repo, resolvedRef, rawRef, tmp, opts) {
-  if (resolvedRef && spec.hosted && SHALLOW_HOSTS.has(spec.hosted.type)) {
-    return git.shallow(repo, resolvedRef.ref, tmp, opts)
+  const ref = resolvedRef ? resolvedRef.ref : rawRef
+  if (spec.hosted && SHALLOW_HOSTS.has(spec.hosted.type)) {
+      return git.shallow(repo, ref, tmp, opts)
   } else {
-    return git.clone(repo, rawRef, tmp, opts)
+      return git.clone(repo, ref, tmp, opts)
   }
 }


### PR DESCRIPTION
Fixed some issues with using semver ranges in Git URLs.

For example calling:
```
const pacote = require('pacote');
pacote.manifest('git+http://github.com/zkat/pacote.git#semver:~6.0.0', {cache: '/cache'}).then(pkg => {
    console.log('package manifest for registry pkg:', pkg)
}).catch(e => {
    console.error(e);
});
```
Would result this error:
```
{ Error: Command failed: C:\Program Files\Git\cmd\git.EXE checkout ~6.0.0
error: pathspec '~6.0.0' did not match any file(s) known to git.

    at ChildProcess.exithandler (child_process.js:271:12)
    at emitTwo (events.js:125:13)
    at ChildProcess.emit (events.js:213:7)
    at maybeClose (internal/child_process.js:927:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:211:5)
  cause:
   { Error: Command failed: C:\Program Files\Git\cmd\git.EXE checkout ~6.0.0
error: pathspec '~6.0.0' did not match any file(s) known to git.

    at ChildProcess.exithandler (child_process.js:271:12)
    at emitTwo (events.js:125:13)
    at ChildProcess.emit (events.js:213:7)
    at maybeClose (internal/child_process.js:927:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:211:5)
     killed: false,
     code: 1,
     signal: null,
     cmd: 'C:\\Program Files\\Git\\cmd\\git.EXE checkout ~6.0.0' },
  killed: false,
  code: 1,
  signal: null,
  cmd: 'C:\\Program Files\\Git\\cmd\\git.EXE checkout ~6.0.0' }
```


