### PR TITLE
fix(git): fix resolution of prerelease versions

### DIFF
--- a/lib/util/git.js
+++ b/lib/util/git.js
@@ -143,8 +143,8 @@ function revs (repo, opts) {
 
           if (type === 'tag') {
             const match = ref.match(/v?(\d+\.\d+\.\d+(?:[-+].+)?)$/)
-            if (match && semver.valid(match[1])) {
-              revs.versions[match[1]] = doc
+            if (match && semver.valid(match[1], true)) {
+              revs.versions[semver.clean(match[1], true)] = doc
             }
           }
 

--- a/lib/util/git.js
+++ b/lib/util/git.js
@@ -142,7 +142,7 @@ function revs (repo, opts) {
           }
 
           if (type === 'tag') {
-            const match = ref.match(/v?(\d+\.\d+\.\d+.*)$/)
+            const match = ref.match(/v?(\d+\.\d+\.\d+(?:[-+].+)?)$/)
             if (match && semver.valid(match[1])) {
               revs.versions[match[1]] = doc
             }

--- a/lib/util/git.js
+++ b/lib/util/git.js
@@ -14,6 +14,7 @@ const path = require('path')
 const pinflight = require('promise-inflight')
 const uniqueFilename = require('unique-filename')
 const which = BB.promisify(require('which'))
+const semver = require('semver')
 
 const GOOD_ENV_VARS = new Set([
   'GIT_ASKPASS',
@@ -141,8 +142,8 @@ function revs (repo, opts) {
           }
 
           if (type === 'tag') {
-            const match = ref.match(/v?(\d+\.\d+\.\d+)$/)
-            if (match) {
+            const match = ref.match(/v?(\d+\.\d+\.\d+.*)$/)
+            if (match && semver.valid(match[1])) {
               revs.versions[match[1]] = doc
             }
           }


### PR DESCRIPTION
Closes #129 

This will match any tags that match with earlier versions AND any tags ending with a valid semver. This maintains the (intentional?) behavior of ignoring any text preceding the valid semver.

This should allow for fully functional git semver dependencies.