### PR TITLE
feat(resolved): add opts.resolved for cache stuff

### DIFF
--- a/lib/fetchers/registry/tarball.js
+++ b/lib/fetchers/registry/tarball.js
@@ -15,8 +15,17 @@ module.exports = tarball
 function tarball (spec, opts) {
   opts = optCheck(opts)
   const stream = new PassThrough()
-  manifest(spec, opts).then(manifest => {
-    stream.emit('manifest', manifest)
+  const p = (opts.resolved && opts.integrity && spec.type === 'version')
+  ? BB.resolve({
+    name: spec.name,
+    version: spec.fetchSpec,
+    _integrity: opts.integrity,
+    _resolved: opts.resolved,
+    _fakeChild: true
+  })
+  : manifest(spec, opts)
+  p.then(manifest => {
+    !manifest._fakeChild && stream.emit('manifest', manifest)
     return pipe(
       fromManifest(manifest, spec, opts).on(
         'integrity', i => stream.emit('integrity', i)
@@ -33,53 +42,72 @@ function fromManifest (manifest, spec, opts) {
   opts.scope = spec.scope || opts.scope
   const stream = new PassThrough()
   const registry = pickRegistry(spec, opts)
-  const uri = getTarballUrl(registry, manifest)
-  fetch(uri, registry, Object.assign({
-    headers: {
-      'pacote-req-type': 'tarball',
-      'pacote-pkg-id': `registry:${
-        spec.type === 'remote'
-        ? spec
-        : `${manifest.name}@${manifest.version}`
-      }`
-    },
-    integrity: manifest._integrity,
-    algorithms: [
-      manifest._integrity
-      ? ssri.parse(manifest._integrity).pickAlgorithm()
-      : 'sha1'
-    ],
-    spec
-  }, opts)).then(res => {
-    const hash = res.headers.get('x-local-cache-hash')
-    if (hash) {
-      stream.emit('integrity', decodeURIComponent(hash))
-    }
-    res.body.on('error', err => stream.emit('error', err))
-    res.body.pipe(stream)
-  }).catch(err => stream.emit('error', err))
+  getTarballUrl(spec, registry, manifest, opts)
+  .then(uri => {
+    return fetch(uri, registry, Object.assign({
+      headers: {
+        'pacote-req-type': 'tarball',
+        'pacote-pkg-id': `registry:${
+          spec.type === 'remote'
+          ? spec
+          : `${manifest.name}@${manifest.version}`
+        }`
+      },
+      integrity: manifest._integrity,
+      algorithms: [
+        manifest._integrity
+        ? ssri.parse(manifest._integrity).pickAlgorithm()
+        : 'sha1'
+      ],
+      spec
+    }, opts))
+    .then(res => {
+      const hash = res.headers.get('x-local-cache-hash')
+      if (hash) {
+        stream.emit('integrity', decodeURIComponent(hash))
+      }
+      res.body.on('error', err => stream.emit('error', err))
+      res.body.pipe(stream)
+    })
+  })
+  .catch(err => stream.emit('error', err))
   return stream
 }
 
-function getTarballUrl (registry, manifest) {
-  // https://github.com/npm/npm/pull/9471
-  //
-  // TL;DR: Some alternative registries host tarballs on http and packuments on
-  // https, and vice-versa. There's also a case where people who can't use SSL
-  // to access the npm registry, for example, might use
-  // `--registry=http://registry.npmjs.org/`. In this case, we need to rewrite
-  // `tarball` to match the protocol.
-  //
+function getTarballUrl (spec, registry, mani, opts) {
   const reg = url.parse(registry)
-  const tarball = url.parse(manifest._resolved)
-  if (reg.hostname === tarball.hostname && reg.protocol !== tarball.protocol) {
-    tarball.protocol = reg.protocol
-    // Ports might be same host different protocol!
-    if (reg.port !== tarball.port) {
-      delete tarball.host
-      tarball.port = reg.port
+  const tarball = url.parse(opts.resolved || mani._resolved)
+  return (
+    // We cannot trust the _resolved field on manifests as-is: there can only
+    // be one registry per "scope" on any individual npm run, so we have to
+    // take any previously resolved fields and check them against the current
+    // registry -- if they don't match, we need to do a manifest fetch from
+    // the correct registry to get the tarball URL we're trying to reference.
+    (reg.hostname === tarball.hostname)
+    ? Promise.resolve(Object.assign(mani, {
+      _resolved: opts.resolved || mani._resolved
+    }))
+    : manifest(spec, opts)
+  )
+  .then(mani => {
+    const tarball = url.parse(mani._resolved)
+    // https://github.com/npm/npm/pull/9471
+    //
+    // TL;DR: Some alternative registries host tarballs on http and packuments
+    // on https, and vice-versa. There's also a case where people who can't use
+    // SSL to access the npm registry, for example, might use
+    // `--registry=http://registry.npmjs.org/`. In this case, we need to
+    // rewrite `tarball` to match the protocol.
+    //
+    if (reg.hostname === tarball.hostname && reg.protocol !== tarball.protocol) {
+      tarball.protocol = reg.protocol
+      // Ports might be same host different protocol!
+      if (reg.port !== tarball.port) {
+        delete tarball.host
+        tarball.port = reg.port
+      }
+      delete tarball.href
     }
-    delete tarball.href
-  }
-  return url.format(tarball)
+    return Promise.resolve(url.format(tarball))
+  })
 }

--- a/lib/util/opt-check.js
+++ b/lib/util/opt-check.js
@@ -25,6 +25,7 @@ function PacoteOptions (opts) {
   this.proxy = opts.proxy
   this.noProxy = opts.noProxy
   this.registry = opts.registry || 'https://registry.npmjs.org'
+  this.resolved = opts.resolved
   this.retry = opts.retry // for npm-registry-client
   this.scope = opts.scope
   this.userAgent = opts.userAgent || `${pkg.name}@${pkg.version}/node@${process.version}+${process.arch} (${process.platform})`


### PR DESCRIPTION
<!--
⚠️🚨 BEFORE FILING A PR: 🚨⚠️

👉🏼 CONTRIBUTING.md 👈🏼 (the "contribution guidelines" up there ☝🏼)

I PROMISE IT'S A VERY VERY SHORT READ.🙇🏼
-->

This is part of integrating `cipm` into npm itself: by passing `opts.resolved` in, we're able to move some of the logic related to fakeChildren in npm right into pacote, so it can be shared. That logic should really be in pacote anyway, though.

As a bonus, my manual perf test shows a ~15%±3% performance improvement when installing with a cold cache and an existing `package-lock.json`!