### PR TITLE
feat(extract): append _resolved and _integrity automatically

### DIFF
--- a/extract.js
+++ b/extract.js
@@ -4,11 +4,17 @@ const BB = require('bluebird')
 
 const cacache = require('cacache')
 const extractStream = require('./lib/extract-stream')
+const fs = require('fs')
 const mkdirp = BB.promisify(require('mkdirp'))
 const npa = require('npm-package-arg')
 const optCheck = require('./lib/util/opt-check')
+const path = require('path')
 const retry = require('promise-retry')
 const rimraf = BB.promisify(require('rimraf'))
+
+const truncateAsync = BB.promisify(fs.truncate)
+const readFileAsync = BB.promisify(fs.readFile)
+const appendFileAsync = BB.promisify(fs.appendFile)
 
 module.exports = extract
 function extract (spec, dest, opts) {
@@ -60,7 +66,7 @@ function extract (spec, dest, opts) {
 
 function extractByDigest (start, spec, dest, opts) {
   return mkdirp(dest).then(() => {
-    const xtractor = extractStream(dest, opts)
+    const xtractor = extractStream(spec, dest, opts)
     const cached = cacache.get.stream.byDigest(opts.cache, opts.integrity, opts)
     cached.pipe(xtractor)
     return new BB((resolve, reject) => {
@@ -80,18 +86,48 @@ function extractByDigest (start, spec, dest, opts) {
 
 let fetch
 function extractByManifest (start, spec, dest, opts) {
+  let integrity = opts.integrity
+  let resolved = opts.resolved
   return mkdirp(dest).then(() => {
-    const xtractor = extractStream(dest, opts)
+    const xtractor = extractStream(spec, dest, opts)
     if (!fetch) {
       fetch = require('./lib/fetch')
     }
     const tardata = fetch.tarball(spec, opts)
+    if (!resolved) {
+      tardata.on('manifest', m => {
+        resolved = m._resolved
+      })
+      tardata.on('integrity', i => {
+        integrity = i
+      })
+    }
     tardata.pipe(xtractor)
     return new BB((resolve, reject) => {
       tardata.on('error', reject)
       xtractor.on('error', reject)
       xtractor.on('close', resolve)
     })
+  }).then(() => {
+    if (!opts.resolved) {
+      const pjson = path.join(dest, 'package.json')
+      return readFileAsync(pjson, 'utf8')
+      .then(str => {
+        return truncateAsync(pjson)
+        .then(() => {
+          return appendFileAsync(pjson, str.replace(
+            /}\s*$/,
+            `\n,"_resolved": ${
+              JSON.stringify(resolved || '')
+            }\n,"_integrity": ${
+              JSON.stringify(integrity || '')
+            }\n,"_from": ${
+              JSON.stringify(spec.toString())
+            }\n}`
+          ))
+        })
+      })
+    }
   }).then(() => {
     opts.log.silly('pacote', `${spec} extracted in ${Date.now() - start}ms`)
   }).catch(err => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5558,9 +5558,9 @@
       }
     },
     "tar": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.2.0.tgz",
-      "integrity": "sha512-8c4LjonehF+KArauze53Tbx1tfPsWiF94cS8wK8s94wSGTWHwdVMLCRxvqe0u8fzTXfnAjlpkpOAQl240K/anw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.3.3.tgz",
+      "integrity": "sha512-v9wjbOXloOIeXifMQGkKhPH3H7tjd+8BubFKOTU+64JpFZ3q2zBfsGlnc7KmyRgl8UxVa1SCRiF3F9tqSOgcaQ==",
       "requires": {
         "chownr": "1.0.1",
         "fs-minipass": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "safe-buffer": "^5.1.1",
     "semver": "^5.4.1",
     "ssri": "^5.1.0",
-    "tar": "^4.2.0",
+    "tar": "^4.3.3",
     "unique-filename": "^1.1.0",
     "which": "^1.3.0"
   },

--- a/test/directory.js
+++ b/test/directory.js
@@ -78,7 +78,7 @@ test('supports directory deps', t => {
         path.join(EXT, 'x', 'mybin'), 'utf8'
       ),
       (xpkg, xsr, xbin) => {
-        t.deepEqual(JSON.parse(xpkg), pkg, 'extracted package.json')
+        t.similar(JSON.parse(xpkg), pkg, 'extracted package.json')
         t.deepEqual(JSON.parse(xsr), sr, 'extracted npm-shrinkwrap.json')
         t.deepEqual(xbin, 'console.log("hi there")', 'extracted binary')
       }

--- a/test/extract-stream.chown.js
+++ b/test/extract-stream.chown.js
@@ -61,7 +61,7 @@ test('accepts gid and uid opts', {skip: !process.getuid}, t => {
     fs: fsClone
   })
   return mockTar(pkg, {stream: true}).then(tarStream => {
-    return pipe(tarStream, extractStream('.', {
+    return pipe(tarStream, extractStream('foo@1', '.', {
       uid: NEWUID,
       gid: NEWGID,
       log: npmlog

--- a/test/extract-stream.compute-mode.js
+++ b/test/extract-stream.compute-mode.js
@@ -3,11 +3,11 @@ const test = require('tap').test
 const computeMode = require('../lib/extract-stream.js')._computeMode
 
 const tests = {
-  "same": {umask: 0o022, entryMode: 0o755, optMode: 0o755, result: 0o755},
-  "opt high": {umask: 0o022, entryMode: 0o755, optMode: 0o777, result: 0o755},
-  "entry high": {umask: 0o022, entryMode: 0o777, optMode: 0o755, result: 0o755},
-  "opt low": {umask: 0o022, entryMode: 0o000, optMode: 0o400, result: 0o400},
-  "entry low": {umask: 0o022, entryMode: 0o400, optMode: 0o000, result: 0o400}
+  'same': {umask: 0o022, entryMode: 0o755, optMode: 0o755, result: 0o755},
+  'opt high': {umask: 0o022, entryMode: 0o755, optMode: 0o777, result: 0o755},
+  'entry high': {umask: 0o022, entryMode: 0o777, optMode: 0o755, result: 0o755},
+  'opt low': {umask: 0o022, entryMode: 0o000, optMode: 0o400, result: 0o400},
+  'entry low': {umask: 0o022, entryMode: 0o400, optMode: 0o000, result: 0o400}
 }
 
 test('computeMode', t => {


### PR DESCRIPTION
This needs tests, but this is an initial spike at getting pacote itself to write out `_resolved` and `_integrity`, instead of burdening npm (or `npm ci`) with this task.