### PR TITLE
fix(deps): move mkdirp and rimraf to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "make-fetch-happen": "^2.6.0",
     "minimatch": "^3.0.4",
     "mississippi": "^2.0.0",
+    "mkdirp": "^0.5.1",
     "normalize-package-data": "^2.4.0",
     "npm-package-arg": "^6.0.0",
     "npm-packlist": "^1.1.10",
@@ -57,6 +58,7 @@
     "promise-inflight": "^1.0.1",
     "promise-retry": "^1.1.1",
     "protoduck": "^5.0.0",
+    "rimraf": "^2.6.2",
     "safe-buffer": "^5.1.1",
     "semver": "^5.5.0",
     "ssri": "^5.2.4",
@@ -65,12 +67,10 @@
     "which": "^1.3.0"
   },
   "devDependencies": {
-    "mkdirp": "^0.5.1",
     "nock": "^9.1.6",
     "npmlog": "^4.1.2",
     "nyc": "^11.4.1",
     "require-inject": "^1.4.2",
-    "rimraf": "^2.6.2",
     "standard": "^10.0.3",
     "standard-version": "^4.3.0",
     "tacks": "^1.2.6",


### PR DESCRIPTION
This only hurts individuals on npm2, as both packages are transitive dependencies of many explicit dependencies already.

53899c7 added runtime require of mkdirp [here](https://github.com/zkat/pacote/blob/53899c75a2ac9ca2121281d559d30486a97b7c45/extract.js#L7)
189cdd2 added runtime require of rimraf [here](https://github.com/zkat/pacote/blob/189cdd29a890e5e749dbcae7089117591c9e815a/extract.js#L10)

Fixes: #128
