### PR TITLE
feat(aliases): add support for registry alias specs

### DIFF
--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -40,6 +40,9 @@ function getFetcher (type) {
     // This is spelled out both to prevent sketchy stuff and to make life
     // easier for bundlers/preprocessors.
     switch (type) {
+      case 'alias':
+        fetchers[type] = require('./fetchers/alias')
+        break
       case 'directory':
         fetchers[type] = require('./fetchers/directory')
         break

--- a/lib/fetchers/alias.js
+++ b/lib/fetchers/alias.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const Fetcher = require('../fetch')
+const fetchRegistry = require('./registry')
+
+const fetchRemote = module.exports = Object.create(null)
+
+Fetcher.impl(fetchRemote, {
+  manifest (spec, opts) {
+    return fetchRegistry.manifest(spec.subSpec, opts)
+  },
+
+  tarball (spec, opts) {
+    return fetchRegistry.tarball(spec.subSpec, opts)
+  },
+
+  fromManifest (manifest, spec, opts) {
+    return fetchRegistry.fromManifest(manifest, spec.subSpec, opts)
+  }
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.4.1.tgz",
       "integrity": "sha512-MPIwsZU9PP9kOrZpyu2042kYA8Fdt/AedQYkYXucHgF9QoD9dXVp0ypuGnHXSR0hTstBxdt85Xkh4JolYfK5wg==",
       "requires": {
-        "humanize-ms": "^1.2.1"
+        "humanize-ms": "1.2.1"
       }
     },
     "ajv": {
@@ -1948,7 +1948,7 @@
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
       "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
       "requires": {
-        "agent-base": "4",
+        "agent-base": "4.2.0",
         "debug": "3.1.0"
       },
       "dependencies": {
@@ -1983,8 +1983,8 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
       "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
       "requires": {
-        "agent-base": "4",
-        "debug": "^3.1.0"
+        "agent-base": "4.2.0",
+        "debug": "3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -2007,7 +2007,7 @@
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
       "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
       "requires": {
-        "ms": "^2.0.0"
+        "ms": "2.1.1"
       }
     },
     "iconv-lite": {
@@ -2609,11 +2609,11 @@
       "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-4.0.0.tgz",
       "integrity": "sha512-RdvnYWRAFgAi2CcxKQ5V8v1VDjxWkU33+kcAoO+t/h3wuHyR5jmbWb6PmUoRqCtBmjwxkZ9PcDJFEsvHBPW9MQ==",
       "requires": {
-        "agentkeepalive": "^3.4.1",
+        "agentkeepalive": "3.4.1",
         "cacache": "11.0.0",
         "http-cache-semantics": "^3.8.1",
-        "http-proxy-agent": "^2.1.0",
-        "https-proxy-agent": "^2.2.1",
+        "http-proxy-agent": "2.1.0",
+        "https-proxy-agent": "2.2.1",
         "lru-cache": "4.1.2",
         "mississippi": "3.0.0",
         "node-fetch-npm": "^2.0.2",
@@ -2873,14 +2873,21 @@
       "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow=="
     },
     "npm-package-arg": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.0.0.tgz",
-      "integrity": "sha512-hwC7g81KLgRmchv9ol6f3Fx4Yyc9ARX5X5niDHVILgpuvf08JRIgOZcEfpFXli3BgESoTrkauqorXm6UbvSgSg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.0.tgz",
+      "integrity": "sha512-zYbhP2k9DbJhA0Z3HKUePUgdB1x7MfIfKssC+WLPFMKTBZKpZh5m13PgexJjCq6KW7j17r0jHWcCpxEqnnncSA==",
       "requires": {
-        "hosted-git-info": "2.5.0",
+        "hosted-git-info": "^2.6.0",
         "osenv": "0.1.5",
         "semver": "5.5.0",
-        "validate-npm-package-name": "3.0.0"
+        "validate-npm-package-name": "^3.0.0"
+      },
+      "dependencies": {
+        "hosted-git-info": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
+          "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
+        }
       }
     },
     "npm-packlist": {
@@ -2897,7 +2904,7 @@
       "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-2.1.0.tgz",
       "integrity": "sha512-q9zLP8cTr8xKPmMZN3naxp1k/NxVFsjxN6uWuO1tiw9gxg7wZWQ/b5UTfzD0ANw2q1lQxdLKTeCCksq+bPSgbQ==",
       "requires": {
-        "npm-package-arg": "6.0.0",
+        "npm-package-arg": "6.1.0",
         "semver": "5.5.0"
       }
     },
@@ -5763,12 +5770,12 @@
       "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
       "requires": {
         "chownr": "1.0.1",
-        "fs-minipass": "^1.2.5",
-        "minipass": "^2.2.4",
-        "minizlib": "^1.1.0",
+        "fs-minipass": "1.2.5",
+        "minipass": "2.2.4",
+        "minizlib": "1.1.0",
         "mkdirp": "0.5.1",
         "safe-buffer": "5.1.1",
-        "yallist": "^3.0.2"
+        "yallist": "3.0.2"
       },
       "dependencies": {
         "minipass": {
@@ -5777,7 +5784,7 @@
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "requires": {
             "safe-buffer": "5.1.1",
-            "yallist": "^3.0.2"
+            "yallist": "3.0.2"
           }
         },
         "yallist": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "mississippi": "^3.0.0",
     "mkdirp": "^0.5.1",
     "normalize-package-data": "^2.4.0",
-    "npm-package-arg": "^6.0.0",
+    "npm-package-arg": "^6.1.0",
     "npm-packlist": "^1.1.10",
     "npm-pick-manifest": "^2.1.0",
     "osenv": "^0.1.5",

--- a/test/registry.manifest.js
+++ b/test/registry.manifest.js
@@ -136,11 +136,30 @@ test('fetches manifest from registry by range', t => {
   })
 })
 
+test('fetches manifest from registry by alias', t => {
+  const srv = tnock(t, OPTS.registry)
+
+  srv.get('/foo').reply(200, META)
+  return manifest('bar@npm:foo@^1.2.0', OPTS).then(pkg => {
+    // Not 1.2.4 because 1.2.3 is `latest`
+    t.deepEqual(pkg, new Manifest(META.versions['1.2.3']), 'picked right manifest')
+  })
+})
+
 test('fetches manifest from scoped registry by range', t => {
   const srv = tnock(t, OPTS.registry)
 
   srv.get('/@usr%2ffoo').reply(200, META)
   return manifest('@usr/foo@^1.2.0', OPTS).then(pkg => {
+    t.deepEqual(pkg, new Manifest(META.versions['1.2.3']), 'got scoped manifest from version')
+  })
+})
+
+test('fetches scoped manifest from registry by alias', t => {
+  const srv = tnock(t, OPTS.registry)
+
+  srv.get('/@usr%2ffoo').reply(200, META)
+  return manifest('bar@npm:@usr/foo@^1.2.0', OPTS).then(pkg => {
     t.deepEqual(pkg, new Manifest(META.versions['1.2.3']), 'got scoped manifest from version')
   })
 })

--- a/test/registry.tarball.js
+++ b/test/registry.tarball.js
@@ -61,6 +61,26 @@ test('basic tarball streaming', function (t) {
   })
 })
 
+test('aliased tarball streaming', t => {
+  const pkg = {
+    'package.json': JSON.stringify({
+      name: 'foo',
+      version: '1.2.3'
+    }),
+    'index.js': 'console.log("hello world!")'
+  }
+  return mockTar(pkg).then(tarData => {
+    const srv = tnock(t, OPTS.registry)
+    srv.get('/foo').reply(200, META(tarData))
+    srv.get('/foo/-/foo-1.2.3.tgz').reply(200, tarData)
+    return getBuff(
+      fetch.tarball(npa('bar@npm:foo@^1.2.3'), OPTS)
+    ).then(data => {
+      t.deepEqual(data, tarData, 'fetched tarball data matches')
+    })
+  })
+})
+
 test('errors if manifest fails', t => {
   const pkg = {
     'package.json': JSON.stringify({


### PR DESCRIPTION
Note: this depends on https://github.com/npm/npm-package-arg/pull/34 landing before it works.