### PR TITLE
feat(tarball): add shasum from tarball when appropriate

### DIFF
--- a/lib/fetchers/directory.js
+++ b/lib/fetchers/directory.js
@@ -29,6 +29,7 @@ Fetcher.impl(fetchDirectory, {
         pkg._hasShrinkwrap = !!sr
         pkg._resolved = spec.fetchSpec
         pkg._integrity = false // Don't auto-calculate integrity
+        pkg._shasum = false // Don't auto-calculate shasum either
         return pkg
       }
     ).then(pkg => {

--- a/lib/fetchers/git.js
+++ b/lib/fetchers/git.js
@@ -112,7 +112,8 @@ function plainManifest (repo, spec, opts) {
         _ref: ref,
         _rawRef: spec.gitCommittish || spec.gitRange,
         _uniqueResolved: resolved,
-        _integrity: false
+        _integrity: false,
+        _shasum: false
       }
     } else {
       // We're SOL and need a full clone :(
@@ -125,7 +126,8 @@ function plainManifest (repo, spec, opts) {
         _rawRef: rawRef,
         _resolved: rawRef && rawRef.match(/^[a-f0-9]{40}$/) && resolved,
         _uniqueResolved: rawRef && rawRef.match(/^[a-f0-9]{40}$/) && resolved,
-        _integrity: false
+        _integrity: false,
+        _shasum: false
       }
     }
   })

--- a/lib/finalize-manifest.js
+++ b/lib/finalize-manifest.js
@@ -98,7 +98,7 @@ function Manifest (pkg, fromTarball, fullMetadata) {
   // and if they don't, we need to extract and read the tarball ourselves.
   // These are details required by the installer.
   this._integrity = pkg._integrity || fromTarball._integrity || null
-  this._shasum = pkg._shasum || null
+  this._shasum = pkg._shasum || fromTarball._shasum || null
   this._shrinkwrap = pkg._shrinkwrap || fromTarball._shrinkwrap || null
   this.bin = pkg.bin || fromTarball.bin || null
 
@@ -153,7 +153,7 @@ function tarballedProps (pkg, spec, opts) {
       needsShrinkwrap && jsonFromStream('npm-shrinkwrap.json', extracted),
       needsManifest && jsonFromStream('package.json', extracted),
       needsBin && getPaths(extracted),
-      needsHash && ssri.fromStream(tarStream),
+      needsHash && ssri.fromStream(tarStream, {algorithms: ['sha1', 'sha512']}),
       needsExtract && pipe(tarStream, extracted),
       (sr, mani, paths, hash) => {
         if (needsManifest && !mani) {
@@ -161,6 +161,10 @@ function tarballedProps (pkg, spec, opts) {
           err.code = 'ENOPACKAGEJSON'
           throw err
         }
+        const hashHexDigest = hash && hash.sha1
+          ? hash.hexDigest()
+          : null
+        delete hash.sha1
         const extraProps = mani || {}
         delete extraProps._resolved
         // drain out the rest of the tarball
@@ -188,7 +192,8 @@ function tarballedProps (pkg, spec, opts) {
           _resolved: (mani && mani._resolved) ||
           (pkg && pkg._resolved) ||
           spec.fetchSpec,
-          _integrity: hash && hash.toString()
+          _integrity: hash && hash.toString(),
+          _shasum: hashHexDigest
         })
       }
     )

--- a/lib/finalize-manifest.js
+++ b/lib/finalize-manifest.js
@@ -163,10 +163,6 @@ function tarballedProps (pkg, spec, opts) {
           err.code = 'ENOPACKAGEJSON'
           throw err
         }
-        const hashHexDigest = hash && hash.sha1
-          ? hash.hexDigest()
-          : null
-        delete hash.sha1
         const extraProps = mani || {}
         delete extraProps._resolved
         // drain out the rest of the tarball
@@ -195,7 +191,7 @@ function tarballedProps (pkg, spec, opts) {
           (pkg && pkg._resolved) ||
           spec.fetchSpec,
           _integrity: needsIntegrity && hash && hash.sha512 && hash.sha512.toString(),
-          _shasum: needsShasum && hashHexDigest
+          _shasum: needsShasum && hash && hash.sha1 && hash.sha1.hexDigest()
         })
       }
     )

--- a/lib/finalize-manifest.js
+++ b/lib/finalize-manifest.js
@@ -190,8 +190,8 @@ function tarballedProps (pkg, spec, opts) {
           _resolved: (mani && mani._resolved) ||
           (pkg && pkg._resolved) ||
           spec.fetchSpec,
-          _integrity: needsIntegrity && hash && hash.sha512 && hash.sha512.toString(),
-          _shasum: needsShasum && hash && hash.sha1 && hash.sha1.hexDigest()
+          _integrity: needsIntegrity && hash && hash.sha512 && hash.sha512[0].toString(),
+          _shasum: needsShasum && hash && hash.sha1 && hash.sha1[0].hexDigest()
         })
       }
     )

--- a/lib/finalize-manifest.js
+++ b/lib/finalize-manifest.js
@@ -194,7 +194,7 @@ function tarballedProps (pkg, spec, opts) {
           _resolved: (mani && mani._resolved) ||
           (pkg && pkg._resolved) ||
           spec.fetchSpec,
-          _integrity: needsIntegrity && hash && hash.toString(),
+          _integrity: needsIntegrity && hash && hash.sha512 && hash.sha512.toString(),
           _shasum: needsShasum && hashHexDigest
         })
       }

--- a/lib/finalize-manifest.js
+++ b/lib/finalize-manifest.js
@@ -140,7 +140,9 @@ function tarballedProps (pkg, spec, opts) {
     pkg.directories &&
     pkg.directories.bin
   ))
-  const needsHash = !pkg || (!pkg._integrity && pkg._integrity !== false)
+  const needsIntegrity = !pkg || (!pkg._integrity && pkg._integrity !== false)
+  const needsShasum = !pkg || (!pkg._shasum && pkg._shasum !== false)
+  const needsHash = needsIntegrity || needsShasum
   const needsManifest = !pkg || !pkg.name
   const needsExtract = needsShrinkwrap || needsBin || needsManifest
   if (!needsShrinkwrap && !needsBin && !needsHash && !needsManifest) {
@@ -192,8 +194,8 @@ function tarballedProps (pkg, spec, opts) {
           _resolved: (mani && mani._resolved) ||
           (pkg && pkg._resolved) ||
           spec.fetchSpec,
-          _integrity: hash && hash.toString(),
-          _shasum: hashHexDigest
+          _integrity: needsIntegrity && hash && hash.toString(),
+          _shasum: needsShasum && hashHexDigest
         })
       }
     )

--- a/test/finalize-manifest.js
+++ b/test/finalize-manifest.js
@@ -230,6 +230,7 @@ test('fills in `bin` if original was an array', t => {
       bin: 'foo'
     },
     _integrity: 'sha1-deadbeefc0ffeebad1dea',
+    _shasum: '75e69d6de79f7347df79e6da77575e',
     _resolved: OPTS.registry + tarballPath,
     _hasShrinkwrap: false
   }

--- a/test/finalize-manifest.js
+++ b/test/finalize-manifest.js
@@ -156,6 +156,33 @@ test('fills in integrity hash if missing', t => {
   })
 })
 
+test('fills in shasum if missing', t => {
+  const tarballPath = 'testing/tarball-1.2.3.tgz'
+  const base = {
+    name: 'testing',
+    version: '1.2.3',
+    _resolved: OPTS.registry + tarballPath,
+    _hasShrinkwrap: false
+  }
+  const sr = {
+    name: base.name,
+    version: base.version
+  }
+  return makeTarball({
+    'package.json': base,
+    'npm-shrinkwrap.json': sr
+  }).then(tarData => {
+    const shasum = ssri.fromData(tarData, {algorithms: ['sha1']}).hexDigest()
+    tnock(t, OPTS.registry).get('/' + tarballPath).reply(200, tarData)
+    return finalizeManifest(base, {
+      name: base.name,
+      type: 'range'
+    }, OPTS).then(manifest => {
+      t.deepEqual(manifest._shasum, shasum, 'shasum successfully added')
+    })
+  })
+})
+
 test('fills in `bin` if `directories.bin` string', t => {
   const tarballPath = 'testing/tarball-1.2.3.tgz'
   const base = {
@@ -254,7 +281,7 @@ test('uses package.json as base if passed null', t => {
         _resolved: OPTS.registry + tarballPath,
         deprecated: false,
         _integrity: ssri.fromData(tarData, {algorithms: ['sha512']}).toString(),
-        _shasum: null, // shasums are only when provided
+        _shasum: ssri.fromData(tarData, {algorithms: ['sha1']}).hexDigest(),
         _shrinkwrap: sr,
         bin: { 'x': path.join('foo', 'x') },
         _id: 'testing@1.2.3'

--- a/test/registry.manifest.js
+++ b/test/registry.manifest.js
@@ -15,9 +15,11 @@ const BASE = {
   version: '1.2.3',
   _hasShrinkwrap: false,
   _integrity: 'sha1-deadbeef',
+  _shasum: '75e69d6de79f',
   _resolved: 'https://foo.bar/x.tgz',
   dist: {
     integrity: 'sha1-deadbeef',
+    shasum: '75e69d6de79f',
     tarball: 'https://foo.bar/x.tgz'
   }
 }
@@ -43,9 +45,11 @@ const META = {
       version: '2.0.4',
       _hasShrinkwrap: false,
       _integrity: 'sha1-deadbeef',
+      _shasum: '75e69d6de79f',
       _resolved: 'https://foo.bar/x.tgz',
       dist: {
         integrity: 'sha1-deadbeef',
+        shasum: '75e69d6de79f',
         tarball: 'https://foo.bar/x.tgz'
       }
     },
@@ -55,9 +59,11 @@ const META = {
       deprecated: 'yes. yes it is.',
       _hasShrinkwrap: false,
       _integrity: 'sha1-deadbeef',
+      _shasum: '75e69d6de79f',
       _resolved: 'https://foo.bar/x.tgz',
       dist: {
         integrity: 'sha1-deadbeef',
+        shasum: '75e69d6de79f',
         tarball: 'https://foo.bar/x.tgz'
       }
     },
@@ -317,9 +323,11 @@ test('package requests are case-sensitive', t => {
     version: '1.2.3',
     _hasShrinkwrap: false,
     _integrity: 'sha1-foobarbaz',
+    _shasum: '75e69d6de79f',
     _resolved: 'https://foo.bar/x.tgz',
     dist: {
       integrity: 'sha1-foobarbaz',
+      shasum: '75e69d6de79f',
       tarball: 'https://foo.bar/x.tgz'
     }
   }


### PR DESCRIPTION
Heya!

This is the result some work done in relation to the discussion here: https://github.com/yarnpkg/yarn/issues/5654

When I started writing it, I thought this was an issue but then saw the tests specifically looking for that `null` value (mentioning: `// shasums are only when provided`). So I hope this is a wanted change! In my eyes it would be consistent with the rest of the behaviour. (I personally need this to facilitate lockfile conversion). But of course, if there's something I'm missing...

**Current Behavior:**
```javascript
pacote.manifest('ansi-regex@https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz')

// Manifest {
//  ...
//  _integrity: 'sha512-TIGnTpdo+...',
//  _shasum: null
// }
```

**After this PR:**
```javascript
pacote.manifest('ansi-regex@https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz')

// Manifest {
//  ...
//  _integrity: 'sha512-TIGnTpdo+...',
//  _shasum: 'c3b33ab5ee360d86e0e628f0468ae7ef27d654df'
// }
```
