### PR TITLE
extract-stream: use subclass instead of one-off transformer

### DIFF
--- a/lib/extract-stream.js
+++ b/lib/extract-stream.js
@@ -7,6 +7,33 @@ const tar = require('tar')
 module.exports = extractStream
 module.exports._computeMode = computeMode
 
+class Transformer extends Minipass {
+  constructor (spec, opts) {
+    super()
+    this.spec = spec
+    this.opts = opts
+    this.str = ''
+  }
+  write (data) {
+    this.str += data
+    return true
+  }
+  end () {
+    const replaced = this.str.replace(
+      /}\s*$/,
+      `\n,"_resolved": ${
+        JSON.stringify(this.opts.resolved || '')
+      }\n,"_integrity": ${
+        JSON.stringify(this.opts.integrity || '')
+      }\n,"_from": ${
+        JSON.stringify(this.spec.toString())
+      }\n}`
+    )
+    super.write(replaced)
+    return super.end()
+  }
+}
+
 function computeMode (fileMode, optMode, umask) {
   return (fileMode | optMode) & ~(umask || 0)
 }
@@ -14,23 +41,7 @@ function computeMode (fileMode, optMode, umask) {
 function pkgJsonTransform (spec, opts) {
   return entry => {
     if (entry.path === 'package.json') {
-      const transformed = new Minipass()
-      let str = ''
-      entry.once('end', () => {
-        const replaced = str.replace(
-          /}\s*$/,
-          `\n,"_resolved": ${
-            JSON.stringify(opts.resolved || '')
-          }\n,"_integrity": ${
-            JSON.stringify(opts.integrity || '')
-          }\n,"_from": ${
-            JSON.stringify(spec.toString())
-          }\n}`
-        )
-        transformed.write(replaced, () => transformed.end())
-      })
-      entry.on('error', e => transformed.emit('error'))
-      entry.on('data', d => { str += d })
+      const transformed = new Transformer(spec, opts)
       return transformed
     }
   }

--- a/lib/finalize-manifest.js
+++ b/lib/finalize-manifest.js
@@ -208,7 +208,6 @@ function jsonFromStream (filename, dataStream) {
         entry.resume()
       } else {
         let data = ''
-        entry.on('data', d => { data += d })
         entry.on('error', cb)
         finished(entry).then(() => {
           try {
@@ -219,6 +218,7 @@ function jsonFromStream (filename, dataStream) {
         }, err => {
           cb(err)
         })
+        entry.on('data', d => { data += d })
       }
     })
   })

--- a/test/finalize-manifest.js
+++ b/test/finalize-manifest.js
@@ -380,8 +380,8 @@ function makeTarball (files) {
   })
   pack.finalize()
   return BB.fromNode(cb => {
-    pack.on('data', function (d) { tarData += d })
     pack.on('error', cb)
     pack.on('end', function () { cb(null, tarData) })
+    pack.on('data', function (d) { tarData += d })
   })
 }

--- a/test/pack-dir.js
+++ b/test/pack-dir.js
@@ -29,10 +29,10 @@ test('packs a directory into a valid tarball', t => {
   const extractor = tar.t()
   extractor.on('entry', (entry) => {
     let data = ''
-    entry.on('data', d => { data += d })
     entry.on('end', () => {
       entries[entry.path] = data
     })
+    entry.on('data', d => { data += d })
   })
   const pack = packDir(manifest, CACHE, CACHE, target)
   return BB.join(pipe(target, extractor), pack, () => {

--- a/test/registry.manifest.shrinkwrap.js
+++ b/test/registry.manifest.shrinkwrap.js
@@ -47,9 +47,9 @@ test('tarball setup', t => {
   pack.entry({ name: 'package/npm-shrinkwrap.json' }, JSON.stringify(SHRINKWRAP))
   pack.entry({ name: 'package/package.json' }, JSON.stringify(PKG))
   pack.finalize()
-  pack.on('data', function (d) { TARBALL += d })
   pack.on('error', function (e) { throw e })
   pack.on('end', function () { t.end() })
+  pack.on('data', function (d) { TARBALL += d })
 })
 
 test('fetches shrinkwrap data if missing + required', t => {

--- a/test/util/git.js
+++ b/test/util/git.js
@@ -16,7 +16,7 @@ function mockRepo (opts) {
   }).then(() => {
     return git._exec(['add', '.'], {cwd})
   }).then(() => {
-    return git._exec(['commit', '-m', '"initial commit"'], {cwd})
+    return git._exec(['commit', '-m', 'initial commit', '--no-gpg-sign'], {cwd})
   }).then(() => {
     return daemon(opts)
   })


### PR DESCRIPTION
This addresses the root cause of why duplicate end events keep happening.