### PR TITLE
Fix temp directory permissions for git fetcher

### DIFF
--- a/lib/fetchers/git.js
+++ b/lib/fetchers/git.js
@@ -157,7 +157,7 @@ function resolve (url, spec, name, opts) {
 function withTmp (opts, cb) {
   if (opts.cache) {
     // cacache has a special facility for working in a tmp dir
-    return cacache.tmp.withTmp(opts.cache, {tmpPrefix: 'git-clone'}, cb)
+    return cacache.tmp.withTmp(opts.cache, {tmpPrefix: 'git-clone', uid: opts.uid, gid: opts.gid}, cb)
   } else {
     const tmpDir = path.join(osenv.tmpdir(), 'pacote-git-tmp')
     const tmpName = uniqueFilename(tmpDir, 'git-clone')


### PR DESCRIPTION
As reported in https://github.com/zkat/pacote/issues/105 `pacote` does
not set permissions on temporary directories for git fetcher when
opts.uid is used to drop privileges (e.g. when using sudo).

This fix passes in the uid and gid to cacache as options. No checking is
required as cacache checks these options before using them.