### PR TITLE
feat(registry): guess tarball URLs in a common case

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ fields. The object has the following shape:
   "bundleDependencies": false || [PkgName],
   "bin": { BinName: Path },
   "_resolved": TarballSource, // different for each package type
+  "_tarballStandardPath": Boolean, // true if the tarball path follows standard convention for registries, and thus can be guessed correctly.
   "_integrity": SubresourceIntegrityHash,
   "_shrinkwrap": null || ShrinkwrapJsonObj
 }
@@ -245,6 +246,16 @@ specifiers. If true, deprecations do not affect version selection.
 
 If `true`, the full packument will be fetched when doing metadata requests. By
 defaul, `pacote` only fetches the summarized packuments, also called "corgis".
+
+##### <a name="opts-guess-resolved"></a> `opts.guessResolved`
+
+* Type: Boolean
+* Default: false
+
+If true, pacote will guess the resolved URL for `version` registry specs if
+`opts.resolved` is omitted. It will only fall back to manifest checking if the
+guessed URL 404s. Enabling this can be a breaking change because it may add
+spurious 404s.
 
 ##### <a name="opts-tag"></a> `opts.tag`
 

--- a/lib/fetchers/registry/manifest.js
+++ b/lib/fetchers/registry/manifest.js
@@ -55,8 +55,19 @@ function annotateManifest (spec, manifest, opts) {
   manifest._resolved = (
     manifest.dist && manifest.dist.tarball
   )
+  const registry = fetch.pickRegistry(spec, opts)
+  const standardPath = `/${spec.name}/-/${spec.name.replace(/^@[^/]+./, '')}-${manifest.version}.tgz`
+  // Manifests with `dist.tarball` that matches the standard registry.npmjs.org
+  // paths get tagged as such. This will allow them to be omitted by pkglock.
+  manifest._tarballStandardPath = (
+    manifest._resolved &&
+    manifest._resolved.indexOf(registry) === 0 &&
+    manifest._resolved.slice(
+      registry.replace(/\/$/, '').length
+    ) === standardPath
+  ) || false
+
   if (!manifest._resolved) {
-    const registry = fetch.pickRegistry(spec, opts)
     const uri = registry.replace(/\/?$/, '/') + spec.escapedName
 
     const err = new Error(
@@ -66,8 +77,7 @@ function annotateManifest (spec, manifest, opts) {
     err.manifest = manifest
     if (!manifest._warnings) { manifest._warnings = [] }
     manifest._warnings.push(err.message)
-    manifest._resolved =
-    `${registry}/${manifest.name}/-/${manifest.name}-${manifest.version}.tgz`
+    manifest._resolved = `${registry}${standardPath}`
   }
   return manifest
 }

--- a/lib/fetchers/registry/tarball.js
+++ b/lib/fetchers/registry/tarball.js
@@ -28,6 +28,22 @@ function tarball (spec, opts) {
       _resolved: opts.resolved,
       _fakeChild: true
     })
+  } else if (!opts.resolved && spec.type === 'version' && opts.guessResolved) {
+    // If no resolved field, make it try a standard-format URL.
+    const guessed = `${
+      registry.replace(/\/+$/, '')
+    }/${spec.name}/-/${
+      // scoped packages get the scope removed from tarball name
+      spec.name.replace(/^@[^/]+\//, '')
+    }-${spec.fetchSpec}.tgz`
+    mani = BB.resolve({
+      name: spec.name,
+      version: spec.fetchSpec,
+      _integrity: opts.integrity,
+      _resolved: guessed,
+      _guessedResolved: true,
+      _fakeChild: true
+    })
   } else {
     // We can't trust opts.resolved if it's going to a separate host.
     mani = manifest(spec, opts)
@@ -46,35 +62,44 @@ function tarball (spec, opts) {
 }
 
 module.exports.fromManifest = fromManifest
-function fromManifest (manifest, spec, opts) {
+function fromManifest (mani, spec, opts) {
   opts = optCheck(opts)
   if (spec.scope) { opts = opts.concat({scope: spec.scope}) }
   const stream = new PassThrough()
   const registry = fetch.pickRegistry(spec, opts)
-  const uri = getTarballUrl(spec, registry, manifest, opts)
-  fetch(uri, opts.concat({
+  const uri = getTarballUrl(spec, registry, mani, opts)
+  const reqOpts = opts.concat({
     headers: {
       'pacote-req-type': 'tarball',
-      'pacote-pkg-id': `registry:${manifest.name}@${uri}`
+      'pacote-pkg-id': `registry:${mani.name}@${uri}`
     },
-    integrity: manifest._integrity,
+    integrity: mani._integrity,
     algorithms: [
-      manifest._integrity
-        ? ssri.parse(manifest._integrity).pickAlgorithm()
+      mani._integrity
+        ? ssri.parse(mani._integrity).pickAlgorithm()
         : 'sha1'
     ],
     spec
-  }, opts))
-    .then(res => {
-      const hash = res.headers.get('x-local-cache-hash')
-      if (hash) {
-        stream.emit('integrity', decodeURIComponent(hash))
-      }
-      res.body.on('error', err => stream.emit('error', err))
-      res.body.pipe(stream)
-      return null
-    })
-    .catch(err => stream.emit('error', err))
+  }, opts)
+  fetch(uri, reqOpts).catch(err => {
+    if (err.code === 'E404' && mani._guessedResolved) {
+      // Retry if we guessed the tarball url.
+      return manifest(spec, opts).then(mani => {
+        const newUri = getTarballUrl(spec, registry, mani, reqOpts)
+        return fetch(newUri, opts)
+      })
+    } else {
+      throw err
+    }
+  }).then(res => {
+    const hash = res.headers.get('x-local-cache-hash')
+    if (hash) {
+      stream.emit('integrity', decodeURIComponent(hash))
+    }
+    res.body.on('error', err => stream.emit('error', err))
+    res.body.pipe(stream)
+    return null
+  }, err => stream.emit('error', err))
   return stream
 }
 

--- a/lib/finalize-manifest.js
+++ b/lib/finalize-manifest.js
@@ -94,6 +94,7 @@ function Manifest (pkg, fromTarball, fullMetadata) {
 
   // These depend entirely on each handler
   this._resolved = pkg._resolved
+  this._tarballStandardPath = pkg._tarballStandardPath || false
 
   // Not all handlers (or registries) provide these out of the box,
   // and if they don't, we need to extract and read the tarball ourselves.

--- a/lib/util/opt-check.js
+++ b/lib/util/opt-check.js
@@ -19,6 +19,7 @@ module.exports = figgyPudding({
   fullMetadata: 'full-metadata',
   'full-metadata': {default: false},
   gid: {},
+  guessResolved: {default: false},
   includeDeprecated: {default: true},
   'include-deprecated': 'includeDeprecated',
   integrity: {},

--- a/test/directory.js
+++ b/test/directory.js
@@ -58,6 +58,7 @@ test('supports directory deps', t => {
       peerDependencies: {},
       deprecated: false,
       _resolved: path.resolve(PKG).replace(/\\/g, '/'),
+      _tarballStandardPath: false,
       _shasum: null,
       _integrity: null,
       _shrinkwrap: sr,

--- a/test/finalize-manifest.js
+++ b/test/finalize-manifest.js
@@ -43,6 +43,7 @@ test('returns a manifest with the right fields', t => {
     bin: './foo.js',
     _resolved: 'resolved.to.this',
     _integrity: 'sha1-deadbeefc0ffeebad1dea',
+    _tarballStandardPath: false,
     _shasum: 'deadbeef1',
     _hasShrinkwrap: false,
     deprecated: 'foo'
@@ -65,6 +66,7 @@ test('returns a manifest with the right fields', t => {
       _shasum: 'deadbeef1',
       _resolved: 'resolved.to.this',
       _integrity: 'sha1-deadbeefc0ffeebad1dea',
+      _tarballStandardPath: false,
       _shrinkwrap: null,
       deprecated: 'foo',
       _id: 'testing@1.2.3'
@@ -94,6 +96,7 @@ test('defaults all field to expected types + values', t => {
       bundleDependencies: false, // because npm does boolean checks on this
       peerDependencies: {},
       bin: null,
+      _tarballStandardPath: false,
       _resolved: base._resolved,
       _integrity: base._integrity,
       _shasum: base._shasum,
@@ -220,6 +223,7 @@ test('fills in `bin` if original was an array', t => {
     },
     _integrity: 'sha1-deadbeefc0ffeebad1dea',
     _shasum: '75e69d6de79f7347df79e6da77575e',
+    _tarballStandardPath: false,
     _resolved: OPTS.registry + tarballPath,
     _hasShrinkwrap: false
   }
@@ -264,6 +268,7 @@ test('uses package.json as base if passed null', t => {
         devDependencies: {},
         bundleDependencies: false,
         peerDependencies: {},
+        _tarballStandardPath: false,
         _resolved: OPTS.registry + tarballPath,
         deprecated: false,
         _integrity: ssri.fromData(tarData, {algorithms: ['sha512']}).toString(),

--- a/test/prefetch.js
+++ b/test/prefetch.js
@@ -19,6 +19,7 @@ const BASE = {
   name: 'foo',
   version: '1.0.0',
   _hasShrinkwrap: false,
+  _tarballStandardPath: false,
   _resolved: 'https://foo.bar/x.tgz',
   dist: {
     tarball: 'https://foo.bar/x.tgz'

--- a/test/registry.manifest.js
+++ b/test/registry.manifest.js
@@ -101,7 +101,7 @@ test('fetches version from registry', t => {
 
   srv.get('/foo').reply(200, META)
   return manifest('foo@1.2.3', OPTS).then(pkg => {
-    t.deepEqual(pkg, PKG, 'got manifest from version')
+    t.matches(pkg, PKG, 'got manifest from version')
   })
 })
 
@@ -110,7 +110,7 @@ test('fetchest tag from registry', t => {
 
   srv.get('/foo').reply(200, META)
   return manifest('foo@latest', OPTS).then(pkg => {
-    t.deepEqual(pkg, PKG, 'got manifest from tag')
+    t.matches(pkg, PKG, 'got manifest from tag')
   })
 })
 
@@ -119,7 +119,7 @@ test('fetches version from scoped registry', t => {
 
   srv.get('/@usr%2ffoo').reply(200, META)
   return manifest('@usr/foo@1.2.3', OPTS).then(pkg => {
-    t.deepEqual(pkg, PKG, 'got scoped manifest from version')
+    t.matches(pkg, PKG, 'got scoped manifest from version')
   })
 })
 
@@ -128,7 +128,7 @@ test('fetches tag from scoped registry', t => {
 
   srv.get('/@usr%2ffoo').reply(200, META)
   return manifest('@usr/foo@latest', OPTS).then(pkg => {
-    t.deepEqual(pkg, PKG, 'got scoped manifest from tag')
+    t.matches(pkg, PKG, 'got scoped manifest from tag')
   })
 })
 
@@ -138,7 +138,7 @@ test('fetches manifest from registry by range', t => {
   srv.get('/foo').reply(200, META)
   return manifest('foo@^1.2.0', OPTS).then(pkg => {
     // Not 1.2.4 because 1.2.3 is `latest`
-    t.deepEqual(pkg, new Manifest(META.versions['1.2.3']), 'picked right manifest')
+    t.matches(pkg, new Manifest(META.versions['1.2.3']), 'picked right manifest')
   })
 })
 
@@ -148,7 +148,7 @@ test('fetches manifest from registry by alias', t => {
   srv.get('/foo').reply(200, META)
   return manifest('bar@npm:foo@^1.2.0', OPTS).then(pkg => {
     // Not 1.2.4 because 1.2.3 is `latest`
-    t.deepEqual(pkg, new Manifest(META.versions['1.2.3']), 'picked right manifest')
+    t.matches(pkg, new Manifest(META.versions['1.2.3']), 'picked right manifest')
   })
 })
 
@@ -157,7 +157,7 @@ test('fetches manifest from scoped registry by range', t => {
 
   srv.get('/@usr%2ffoo').reply(200, META)
   return manifest('@usr/foo@^1.2.0', OPTS).then(pkg => {
-    t.deepEqual(pkg, new Manifest(META.versions['1.2.3']), 'got scoped manifest from version')
+    t.matches(pkg, new Manifest(META.versions['1.2.3']), 'got scoped manifest from version')
   })
 })
 
@@ -166,7 +166,7 @@ test('fetches scoped manifest from registry by alias', t => {
 
   srv.get('/@usr%2ffoo').reply(200, META)
   return manifest('bar@npm:@usr/foo@^1.2.0', OPTS).then(pkg => {
-    t.deepEqual(pkg, new Manifest(META.versions['1.2.3']), 'got scoped manifest from version')
+    t.matches(pkg, new Manifest(META.versions['1.2.3']), 'got scoped manifest from version')
   })
 })
 
@@ -177,12 +177,12 @@ test('supports opts.includeDeprecated', t => {
   return manifest('foo@^2', Object.assign({
     includeDeprecated: true
   }, OPTS)).then(pkg => {
-    t.deepEqual(pkg, new Manifest(META.versions['2.0.5']), 'got deprecated')
+    t.matches(pkg, new Manifest(META.versions['2.0.5']), 'got deprecated')
     return manifest('foo@^2.0', Object.assign({
       includeDeprecated: false
     }, OPTS))
   }).then(pkg => {
-    t.deepEqual(pkg, new Manifest(META.versions['2.0.4']), 'non-deprecated')
+    t.matches(pkg, new Manifest(META.versions['2.0.4']), 'non-deprecated')
   })
 })
 
@@ -201,7 +201,7 @@ test('sends auth token if passed in opts', t => {
     'authorization', 'Bearer ' + TOKEN
   ).reply(200, META)
   return manifest('foo@1.2.3', opts).then(pkg => {
-    t.deepEqual(pkg, PKG, 'got manifest from version')
+    t.matches(pkg, PKG, 'got manifest from version')
   })
 })
 
@@ -210,7 +210,7 @@ test('treats options as optional', t => {
 
   srv.get('/foo').reply(200, META)
   return manifest('foo@1.2.3').then(pkg => {
-    t.deepEqual(pkg, PKG, 'used default options')
+    t.matches(pkg, PKG, 'used default options')
   })
 })
 
@@ -223,7 +223,7 @@ test('uses scope from spec for registry lookup', t => {
   const srv = tnock(t, OPTS.registry)
   srv.get('/@myscope%2ffoo').reply(200, META)
   return manifest('@myscope/foo@1.2.3', opts).then(pkg => {
-    t.deepEqual(pkg, PKG, 'used scope to pick registry')
+    t.matches(pkg, PKG, 'used scope to pick registry')
   })
 })
 
@@ -240,13 +240,13 @@ test('uses scope opt for registry lookup', t => {
       // scope option takes priority
       registry: 'nope'
     }).then(pkg => {
-      t.deepEqual(pkg, PKG, 'used scope to pick registry')
+      t.matches(pkg, PKG, 'used scope to pick registry')
     }),
     manifest('bar@latest', {
       '@myscope:registry': OPTS.registry,
       scope: 'myscope' // @ auto-inserted
     }).then(pkg => {
-      t.deepEqual(pkg, PKG, 'scope @ was auto-inserted')
+      t.matches(pkg, PKG, 'scope @ was auto-inserted')
     })
   )
 })
@@ -256,7 +256,7 @@ test('defaults to registry.npmjs.org if no option given', t => {
 
   srv.get('/foo').reply(200, META)
   return manifest('foo@1.2.3', { registry: undefined }).then(pkg => {
-    t.deepEqual(pkg, PKG, 'used npm registry')
+    t.matches(pkg, PKG, 'used npm registry')
   })
 })
 
@@ -274,7 +274,7 @@ test('supports scoped auth', t => {
     'authorization', 'Bearer ' + TOKEN
   ).reply(200, META)
   return manifest('foo@1.2.3', opts).then(pkg => {
-    t.deepEqual(pkg, PKG, 'used scope to pick registry and auth')
+    t.matches(pkg, PKG, 'used scope to pick registry and auth')
   })
 })
 
@@ -293,7 +293,7 @@ test('sends auth token if passed in global opts', t => {
     'authorization', 'Bearer ' + TOKEN
   ).reply(200, META)
   return manifest('foo@1.2.3', opts).then(pkg => {
-    t.deepEqual(pkg, PKG, 'got manifest from version')
+    t.matches(pkg, PKG, 'got manifest from version')
   })
 })
 
@@ -312,7 +312,7 @@ test('sends basic authorization if alwaysAuth and _auth', t => {
     'authorization', 'Basic ' + TOKEN
   ).reply(200, META)
   return manifest('foo@1.2.3', opts).then(pkg => {
-    t.deepEqual(pkg, PKG, 'got manifest from version')
+    t.matches(pkg, PKG, 'got manifest from version')
   })
 })
 
@@ -342,10 +342,10 @@ test('package requests are case-sensitive', t => {
 
   return BB.join(
     manifest('Foo@1.2.3', OPTS).then(pkg => {
-      t.deepEqual(pkg, CASEDPKG, 'got Cased package')
+      t.matches(pkg, CASEDPKG, 'got Cased package')
     }),
     manifest('foo@1.2.3', OPTS).then(pkg => {
-      t.deepEqual(pkg, PKG, 'got lowercased package')
+      t.matches(pkg, PKG, 'got lowercased package')
     })
   )
 })
@@ -358,10 +358,10 @@ test('handles server-side case-normalization', t => {
 
   return BB.join(
     manifest('Cased@1.2.3', OPTS).then(pkg => {
-      t.deepEqual(pkg, PKG, 'got Cased package')
+      t.matches(pkg, PKG, 'got Cased package')
     }),
     manifest('cased@latest', OPTS).then(pkg => {
-      t.deepEqual(pkg, PKG, 'got lowercased package')
+      t.matches(pkg, PKG, 'got lowercased package')
     })
   )
 })
@@ -393,7 +393,7 @@ test('recovers from request errors', t => {
   })
 
   manifest('foo@1.2.3', opts).then(pkg => {
-    t.deepEqual(pkg, PKG, 'got a manifest')
+    t.matches(pkg, PKG, 'got a manifest')
   })
 })
 
@@ -414,7 +414,39 @@ test('optionally annotates manifest with request-related metadata', t => {
 
   srv.get('/foo').reply(200, META)
   return manifest('foo@1.2.3', opts).then(pkg => {
-    t.deepEqual(pkg, annotated, 'additional data was added to pkg')
+    t.matches(pkg, annotated, 'additional data was added to pkg')
+  })
+})
+
+test('adds _tarballStandardPath helper based on dist.tarball', t => {
+  const srv = tnock(t, OPTS.registry)
+  const opts = {
+    log: OPTS.log,
+    registry: OPTS.registry,
+    retry: false,
+    where: 'right here'
+  }
+  const newBase = {
+    name: 'foo',
+    version: '1.2.4',
+    _hasShrinkwrap: false,
+    _tarballStandardPath: true,
+    _integrity: 'sha1-blablabla',
+    _shasum: '75e69d6de79f',
+    _resolved: `${OPTS.registry}/foo/-/foo-1.2.4.tgz`,
+    dist: {
+      integrity: 'sha1-blablabla',
+      shasum: '75e69d6de79f',
+      tarball: `${OPTS.registry}/foo/-/foo-1.2.4.tgz`
+    }
+  }
+
+  srv.get('/foo').reply(200, {
+    'dist-tags': {latest: '1.2.4'},
+    versions: {'1.2.4': newBase}
+  })
+  return manifest('foo@1.2.4', opts).then(pkg => {
+    t.matches(pkg, new Manifest(newBase), '_tarballStandardPath true')
   })
 })
 
@@ -433,6 +465,6 @@ test('sends npm-session header if passed in opts', t => {
     'npm-session', SESSION_ID
   ).reply(200, META)
   return manifest('foo@1.2.3', opts).then(pkg => {
-    t.deepEqual(pkg, PKG, 'npm-session header was sent')
+    t.matches(pkg, PKG, 'npm-session header was sent')
   })
 })


### PR DESCRIPTION
This should make it so pkglock can omit `resolved` if the resolved
URL it fetched from last time around matched the registry.

<!--
⚠️🚨 BEFORE FILING A PR: 🚨⚠️

👉🏼 CONTRIBUTING.md 👈🏼 (the "contribution guidelines" up there ☝🏼)

I PROMISE IT'S A VERY VERY SHORT READ.🙇🏼
-->
