### PR TITLE
Add option to extract package.json as-is.

### DIFF
--- a/extract.js
+++ b/extract.js
@@ -25,7 +25,7 @@ function extract (spec, dest, opts) {
     return tryExtract(spec, stream, dest, opts)
   })
     .then(() => {
-      if (!opts.resolved) {
+      if (!opts.resolved && !opts.unmodified) {
         const pjson = path.join(dest, 'package.json')
         return readFileAsync(pjson, 'utf8')
           .then(str => truncateAsync(pjson)

--- a/lib/util/opt-check.js
+++ b/lib/util/opt-check.js
@@ -39,7 +39,8 @@ module.exports = figgyPudding({
   tag: { default: 'latest' },
   uid: {},
   umask: {},
-  where: {}
+  where: {},
+  unmodified: {}
 }, {
   other (key) {
     return key.match(AUTH_REGEX) || key.match(SCOPE_REGISTRY_REGEX)


### PR DESCRIPTION
I'm working on a project to ensure the NPM versions of packages match the code on GitHub. Pacote's modifications to package.json break that, so I needed an option to turn it off.