### PR TITLE
fix(directory, finalize-manifest): strip byte order marker from JSON

### DIFF
--- a/lib/fetchers/directory.js
+++ b/lib/fetchers/directory.js
@@ -5,6 +5,7 @@ const BB = require('bluebird')
 const Fetcher = require('../fetch')
 const glob = BB.promisify(require('glob'))
 const packDir = require('../util/pack-dir')
+const readJson = require('../util/read-json')
 const path = require('path')
 const pipe = BB.promisify(require('mississippi').pipe)
 const through = require('mississippi').through
@@ -34,11 +35,11 @@ Fetcher.impl(fetchDirectory, {
     const pkgPath = path.join(spec.fetchSpec, 'package.json')
     const srPath = path.join(spec.fetchSpec, 'npm-shrinkwrap.json')
     return BB.join(
-      readFileAsync(pkgPath).then(JSON.parse).catch({ code: 'ENOENT' }, err => {
+      readFileAsync(pkgPath).then(readJson).catch({ code: 'ENOENT' }, err => {
         err.code = 'ENOPACKAGEJSON'
         throw err
       }),
-      readFileAsync(srPath).then(JSON.parse).catch({ code: 'ENOENT' }, () => null),
+      readFileAsync(srPath).then(readJson).catch({ code: 'ENOENT' }, () => null),
       (pkg, sr) => {
         pkg._shrinkwrap = sr
         pkg._hasShrinkwrap = !!sr

--- a/lib/finalize-manifest.js
+++ b/lib/finalize-manifest.js
@@ -13,6 +13,7 @@ const path = require('path')
 const pipe = BB.promisify(require('mississippi').pipe)
 const ssri = require('ssri')
 const tar = require('tar')
+const readJson = require('./util/read-json')
 
 // `finalizeManifest` takes as input the various kinds of manifests that
 // manifest handlers ('lib/fetchers/*.js#manifest()') return, and makes sure
@@ -212,7 +213,7 @@ function jsonFromStream (filename, dataStream) {
         entry.on('error', cb)
         finished(entry).then(() => {
           try {
-            cb(null, JSON.parse(data))
+            cb(null, readJson(data))
           } catch (err) {
             cb(err)
           }

--- a/lib/util/read-json.js
+++ b/lib/util/read-json.js
@@ -1,0 +1,15 @@
+'use strict'
+
+module.exports = function (content) {
+  // Code also yanked from read-package-json.
+  function stripBOM (content) {
+    content = content.toString()
+    // Remove byte order marker. This catches EF BB BF (the UTF-8 BOM)
+    // because the buffer-to-string conversion in `fs.readFileSync()`
+    // translates it to FEFF, the UTF-16 BOM.
+    if (content.charCodeAt(0) === 0xFEFF) return content.slice(1)
+    return content
+  }
+
+  return JSON.parse(stripBOM(content))
+}

--- a/test/read-json.js
+++ b/test/read-json.js
@@ -1,0 +1,48 @@
+'use strict'
+
+const BB = require('bluebird')
+
+const fs = BB.promisifyAll(require('fs'))
+const mkdirp = BB.promisify(require('mkdirp'))
+const path = require('path')
+const test = require('tap').test
+const tar = require('tar-stream')
+const zlib = require('zlib')
+
+const manifest = require('../manifest')
+
+const CACHE = require('./util/test-dir')(__filename)
+
+test('support package.json with Byte Order Mark (BOM)', t => {
+  var extract = tar.extract()
+  var data = ''
+  extract.on('entry', function (header, stream, next) {
+    stream.on('data', function (chunk) {
+      if (header.name === 'package/package.json') {
+        data += chunk
+      }
+    })
+
+    stream.on('end', function () {
+      next()
+    })
+
+    stream.resume()
+  })
+
+  extract.on('finish', function () {
+    let PKG = path.join(CACHE, 'package')
+    mkdirp(PKG).then(() => {
+      // Prepend a BOM to the json data here instead of creating a fixture.
+      let bomdata = '\ufeff' + data
+      fs.writeFile(path.join(PKG, 'package.json'), bomdata, function () {
+        t.resolves(manifest(PKG), 'successfully read package.json with Byte Order Mark (BOM)')
+        t.end()
+      })
+    })
+  })
+
+  fs.createReadStream(path.join(CACHE, '../../fixtures/no-shrinkwrap.tgz'))
+    .pipe(zlib.createGunzip())
+    .pipe(extract)
+})


### PR DESCRIPTION
It looks like other parts of the npm toolchain already deal with byte order markers (BOM), specifically [`read-package-json`](https://github.com/npm/read-package-json/blob/latest/read-json.js#L55). 

I noticed an issue when the `npm pack` command raised an error on a local directory. The issue was the BOM inside the `package.json` file causing `JSON.parse` to choke :0

Calling `npm publish` on that same BOM + package.json worked fine.