### PR TITLE
Fix "TypeError: err.code.match is not a function" error

### DIFF
--- a/lib/with-tarball-stream.js
+++ b/lib/with-tarball-stream.js
@@ -107,7 +107,7 @@ function withTarballStream (spec, opts, streamHandler) {
               // Retry once if we have a cache, to clear up any weird conditions.
               // Don't retry network errors, though -- make-fetch-happen has already
               // taken care of making sure we're all set on that front.
-              if (opts.cache && err.code && !err.code.match(/^E\d{3}$/)) {
+              if (opts.cache && err.code && !String(err.code).match(/^E\d{3}$/)) {
                 if (err.code === 'EINTEGRITY' || err.code === 'Z_DATA_ERROR') {
                   opts.log.warn('tarball', `tarball data for ${spec} (${opts.integrity}) seems to be corrupted. Trying one more time.`)
                 }


### PR DESCRIPTION
I hit this on CI running npm v6.7.0 a couple times, and then the error
went away before I could find out what the root cause was, but the issue
sounds worth resolving anyways.

Here is the stacktrace I could recover:

```
npm info teardown Done in 0s
npm verb stack TypeError: err.code.match is not a function
npm verb stack     at BB.try.catch.err (/usr/lib/node_modules/npm/node_modules/pacote/lib/with-tarball-stream.js:110:55)
npm verb stack     at tryCatcher (/usr/lib/node_modules/npm/node_modules/bluebird/js/release/util.js:16:23)
npm verb stack     at Promise._settlePromiseFromHandler (/usr/lib/node_modules/npm/node_modules/bluebird/js/release/promise.js:512:31)
npm verb stack     at Promise._settlePromise (/usr/lib/node_modules/npm/node_modules/bluebird/js/release/promise.js:569:18)
npm verb stack     at Promise._settlePromise0 (/usr/lib/node_modules/npm/node_modules/bluebird/js/release/promise.js:614:10)
npm verb stack     at Promise._settlePromises (/usr/lib/node_modules/npm/node_modules/bluebird/js/release/promise.js:690:18)
npm verb stack     at _drainQueueStep (/usr/lib/node_modules/npm/node_modules/bluebird/js/release/async.js:138:12)
npm verb stack     at _drainQueue (/usr/lib/node_modules/npm/node_modules/bluebird/js/release/async.js:131:9)
npm verb stack     at Async._drainQueues (/usr/lib/node_modules/npm/node_modules/bluebird/js/release/async.js:147:5)
npm verb stack     at Immediate.Async.drainQueues (/usr/lib/node_modules/npm/node_modules/bluebird/js/release/async.js:17:14)
npm verb stack     at runCallback (timers.js:810:20)
npm verb stack     at tryOnImmediate (timers.js:768:5)
npm verb stack     at processImmediate [as _immediateCallback] (timers.js:745:5)
npm verb cwd /usr/src/app
npm verb Linux 4.13.0-25-generic
npm verb argv "/usr/bin/node" "/usr/bin/npm" "ci" "--verbose"
npm verb node v8.15.0
npm verb npm  v6.7.0
npm ERR! err.code.match is not a function
npm verb exit [ 1, true ]
```

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>

<!--
⚠️🚨 BEFORE FILING A PR: 🚨⚠️

👉🏼 CONTRIBUTING.md 👈🏼 (the "contribution guidelines" up there ☝🏼)

I PROMISE IT'S A VERY VERY SHORT READ.🙇🏼
-->
