### PR TITLE
feat(transports) add support for IPFS and IPNS

### DIFF
--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -74,6 +74,12 @@ function getFetcher (type) {
       case 'version':
         fetchers[type] = require('./fetchers/version')
         break
+      case 'ipfs':
+        fetchers[type] = require('./fetchers/ipfs')
+        break
+      case 'ipns':
+        fetchers[type] = require('./fetchers/ipns')
+        break
       default:
         throw new Error(`Invalid dependency type requested: ${type}`)
     }

--- a/lib/fetchers/ipfs.js
+++ b/lib/fetchers/ipfs.js
@@ -1,0 +1,37 @@
+'use strict'
+
+const BB = require('bluebird')
+const Fetcher = require('../fetch')
+const getIpfs = require('../util/get-ipfs')
+const CID = require('ipfs-http-client').CID
+const PassThrough = require('stream').PassThrough
+
+const fetchIPFS = module.exports = Object.create(null)
+
+Fetcher.impl(fetchIPFS, {
+  packument () {
+    return BB.reject(new Error('Not implemented yet'))
+  },
+
+  manifest () {
+    return BB.resolve(null)
+  },
+
+  tarball (spec, opts) {
+    try {
+      const ipfs = getIpfs(opts)
+      const cid = new CID(spec.rawSpec.trim().replace('ipfs://', ''))
+
+      return ipfs.catReadableStream(cid)
+    } catch (err) {
+      const stream = new PassThrough()
+      stream.emit('error', err)
+
+      return stream
+    }
+  },
+
+  fromManifest (manifest, spec, opts) {
+    return this.tarball(manifest || spec, opts)
+  }
+})

--- a/lib/fetchers/ipns.js
+++ b/lib/fetchers/ipns.js
@@ -1,0 +1,108 @@
+'use strict'
+
+const BB = require('bluebird')
+const Fetcher = require('../fetch')
+const PassThrough = require('stream').PassThrough
+const pickManifest = require('npm-pick-manifest')
+const pipe = BB.promisify(require('mississippi').pipe)
+const optCheck = require('../util/opt-check')
+const LRU = require('lru-cache')
+const getIpfs = require('../util/get-ipfs')
+
+const MEMO = new LRU({
+  length: m => m._contentLength,
+  max: 200 * 1024 * 1024, // 200MB
+  maxAge: 30 * 1000 // 30s
+})
+
+const resolveIpnsName = (name, ipfs, opts) => {
+  if (MEMO.has(name)) {
+    return BB.resolve(MEMO.get(name))
+  }
+
+  opts.log.info('ipns', `Resolving ${name}`)
+
+  let start = Date.now()
+
+  return ipfs.name.resolve(name)
+    .then(cid => {
+      opts.log.info('ipns', `Resolved ${name} to ${cid}`, Date.now() - start, 'ms')
+
+      MEMO.set(name, cid)
+
+      return cid
+    })
+}
+
+const fetchIPNS = module.exports = Object.create(null)
+
+Fetcher.impl(fetchIPNS, {
+  clearMemoized () {
+    MEMO.reset()
+  },
+
+  packument (spec, opts) {
+    opts = optCheck(opts)
+
+    const ipfs = getIpfs(opts)
+    const result = spec.rawSpec.match(/.*:\/\/([a-zA-Z0-9]*)#?(.*)/)
+    const name = result[1]
+
+    return resolveIpnsName(name, ipfs, opts)
+      .then(cid => ipfs.cat(cid))
+      .then(buf => JSON.parse(buf.toString()))
+  },
+
+  manifest (spec, opts) {
+    opts = optCheck(opts)
+
+    const result = spec.rawSpec.match(/.*:\/\/([a-zA-Z0-9]*)#?(.*)/)
+    let version = result[2]
+
+    return this.packument(spec, opts)
+      .then(packument => {
+        if (!version) {
+          if (packument['dist-tags'] && packument['dist-tags'].latest) {
+            version = packument['dist-tags'].latest
+          } else {
+            version = '*'
+          }
+        }
+
+        return pickManifest(packument, version, {
+          defaultTag: opts.defaultTag,
+          enjoyBy: opts.enjoyBy,
+          includeDeprecated: opts.includeDeprecated
+        })
+      })
+  },
+
+  tarball (spec, opts) {
+    const stream = new PassThrough()
+
+    this.manifest(spec, opts)
+      .then(manifest => {
+        return pipe(this.fromManifest(
+          manifest, spec, opts
+        ), stream)
+      })
+      .catch(err => stream.emit('error', err))
+
+    return stream
+  },
+
+  fromManifest (manifest, spec, opts) {
+    opts = optCheck(opts)
+
+    const ipfs = getIpfs(opts)
+
+    if (!manifest.dist.cid) {
+      const err = new Error(`No CID found for ${manifest.name}@${manifest.version}`)
+      err.code = 'ENOCID'
+
+      throw err
+    }
+
+    return ipfs.catReadableStream(`/ipfs/${manifest.dist.cid}`)
+  }
+})

--- a/lib/util/get-ipfs.js
+++ b/lib/util/get-ipfs.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const ipfsClient = require('ipfs-http-client')
+
+let node
+
+const getIpfs = (opts) => {
+  if (!opts['ipfs-url']) {
+    const err = new Error('Please specify an IPFS daemon to connect to, e.g. --ipfs-url=/ip4/127.0.0.1/tcp/5001 or npm config set ipfs-url /ip4/127.0.0.1/tcp/5001')
+    err.code = 'ENOIPFSURL'
+
+    throw err
+  }
+
+  if (!node) {
+    node = ipfsClient(opts['ipfs-url'])
+  }
+
+  return node
+}
+
+module.exports = getIpfs

--- a/lib/util/opt-check.js
+++ b/lib/util/opt-check.js
@@ -23,6 +23,7 @@ module.exports = figgyPudding({
   'full-metadata': { default: false },
   gid: {},
   git: {},
+  'ipfs-url': {},
   includeDeprecated: { default: true },
   'include-deprecated': 'includeDeprecated',
   integrity: {},

--- a/package-lock.json
+++ b/package-lock.json
@@ -339,6 +339,11 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
+    "asmcrypto.js": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/asmcrypto.js/-/asmcrypto.js-2.3.2.tgz",
+      "integrity": "sha512-3FgFARf7RupsZETQ1nHnhLUUvpcttcCq1iZCaVAbJZbCZ5VNRrNyvpDyHTOb0KC3llFcsyOT/a99NZcCbeiEsA=="
+    },
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -346,6 +351,16 @@
       "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
+      }
+    },
+    "asn1.js": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.0.1.tgz",
+      "integrity": "sha512-aO8EaEgbgqq77IEw+1jfx5c9zTbzvkfuRBuZsSsPnTHMkmd5AI4J6OtITLZFa381jReeaQL67J0GBTUu0+ZTVw==",
+      "requires": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "assert-plus": {
@@ -408,6 +423,14 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
+    "base-x": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.5.tgz",
+      "integrity": "sha512-C3picSgzPSLE+jW3tcBzJoGwitOtazb5B+5YmAxZm2ybmTi9LNgAtDO/jjVEBZwHoXmDBZ9m/IELj3elJVRBcA==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -417,11 +440,32 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "bignumber.js": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.1.1.tgz",
+      "integrity": "sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ=="
+    },
     "bind-obj-methods": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bind-obj-methods/-/bind-obj-methods-2.0.0.tgz",
       "integrity": "sha512-3/qRXczDi2Cdbz6jE+W3IflJOutRVica8frpBn14de1mBOkzDo+6tY33kNhvkw54Kn3PzRRD2VnGbGPcTAk4sw==",
       "dev": true
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "bip66": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
+      "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "bl": {
       "version": "1.2.2",
@@ -459,10 +503,32 @@
         }
       }
     },
+    "blakejs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
+      "integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
+    },
     "bluebird": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
       "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
+    },
+    "bn.js": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+    },
+    "borc": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.0.tgz",
+      "integrity": "sha512-hKTxeYt3AIzIG45epJHv8xJYSF0ktp7nZgFsqi5cPzoL3T8qKMPeUlqydORy6j3NWZvRDANx30PjpTmGho69Gw==",
+      "requires": {
+        "bignumber.js": "^8.0.1",
+        "commander": "^2.15.0",
+        "ieee754": "^1.1.8",
+        "iso-url": "~0.4.4",
+        "json-text-sequence": "~0.1.0"
+      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -473,11 +539,37 @@
         "concat-map": "0.0.1"
       }
     },
+    "brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+    },
     "browser-process-hrtime": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
       "dev": true
+    },
+    "browserify-aes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "requires": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+      "requires": {
+        "base-x": "^3.0.2"
+      }
     },
     "buffer-alloc": {
       "version": "1.2.0",
@@ -507,10 +599,20 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
+    "buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
+    },
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+    },
+    "builtin-status-codes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
     },
     "builtins": {
       "version": "1.0.3",
@@ -663,11 +765,36 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
       "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
     },
+    "cids": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/cids/-/cids-0.5.8.tgz",
+      "integrity": "sha512-Ye8TZP3YQfy0j+i5k+LPHdTY3JOvTwN1pxds44p6BRUv8PTMOAF/Vt4Bc+oiIQ0Sktn0iftkUHgqKNHIMwhshA==",
+      "requires": {
+        "class-is": "^1.1.0",
+        "multibase": "~0.6.0",
+        "multicodec": "~0.5.0",
+        "multihashes": "~0.4.14"
+      }
+    },
+    "cipher-base": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
       "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
+    },
+    "class-is": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/class-is/-/class-is-1.1.0.tgz",
+      "integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw=="
     },
     "clean-yaml-object": {
       "version": "0.1.0",
@@ -746,6 +873,11 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
+    },
+    "commander": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
     },
     "compare-func": {
       "version": "1.3.2",
@@ -1093,6 +1225,31 @@
         }
       }
     },
+    "create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "requires": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "requires": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
@@ -1164,7 +1321,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
       "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
-      "dev": true,
       "requires": {
         "ms": "^2.1.1"
       }
@@ -1278,6 +1434,16 @@
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true
     },
+    "delimit-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
+      "integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs="
+    },
+    "detect-node": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
+      "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
+    },
     "diff": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
@@ -1329,6 +1495,16 @@
         }
       }
     },
+    "drbg.js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
+      "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
+      "requires": {
+        "browserify-aes": "^1.0.6",
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4"
+      }
+    },
     "duplexify": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.3.tgz",
@@ -1348,6 +1524,20 @@
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
+      }
+    },
+    "elliptic": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
+      "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
+      "requires": {
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
       }
     },
     "encoding": {
@@ -1835,6 +2025,15 @@
       "integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y=",
       "dev": true
     },
+    "evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "requires": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      }
+    },
     "execa": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
@@ -1924,6 +2123,11 @@
         "object-assign": "^4.0.1"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+    },
     "find-root": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
@@ -1951,6 +2155,11 @@
         "graceful-fs": "^4.1.2",
         "write": "^0.2.1"
       }
+    },
+    "flatmap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/flatmap/-/flatmap-0.0.3.tgz",
+      "integrity": "sha1-Hxik2TgVLUlZZfnJWNkjqy3WabQ="
     },
     "flush-write-stream": {
       "version": "1.0.2",
@@ -2039,8 +2248,7 @@
     "fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "dev": true
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "fs-exists-cached": {
       "version": "1.0.0",
@@ -2391,6 +2599,34 @@
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true
     },
+    "hash-base": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+      "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+      "requires": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
@@ -2472,6 +2708,11 @@
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
       "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+    },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "iferr": {
       "version": "0.1.5",
@@ -2626,6 +2867,183 @@
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
+    "ip-regex": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
+    },
+    "ipfs-block": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/ipfs-block/-/ipfs-block-0.8.0.tgz",
+      "integrity": "sha512-znNtFRxXlJYP1/Q4u0tGFJUceH9pNww8WA+zair6T3y7d28m+vtUDJGn96M7ZlFFSkByQyQsAiq2ssNhKtMzxw==",
+      "requires": {
+        "cids": "~0.5.5",
+        "class-is": "^1.1.0"
+      }
+    },
+    "ipfs-http-client": {
+      "version": "30.1.1",
+      "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-30.1.1.tgz",
+      "integrity": "sha512-tMqSwEhW57VnjHDBLjKKlgtAvlhkqVSR3oIFC0IiGnaM1nzcw7pbFBoHaFzl0PKIuXm40a5bJt85Rm2trYx+Ag==",
+      "requires": {
+        "async": "^2.6.1",
+        "bignumber.js": "^8.0.2",
+        "bl": "^3.0.0",
+        "bs58": "^4.0.1",
+        "cids": "~0.5.5",
+        "concat-stream": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
+        "debug": "^4.1.0",
+        "detect-node": "^2.0.4",
+        "end-of-stream": "^1.4.1",
+        "err-code": "^1.1.2",
+        "flatmap": "0.0.3",
+        "glob": "^7.1.3",
+        "ipfs-block": "~0.8.0",
+        "ipld-dag-cbor": "~0.13.1",
+        "ipld-dag-pb": "~0.15.3",
+        "is-ipfs": "~0.6.0",
+        "is-pull-stream": "0.0.0",
+        "is-stream": "^1.1.0",
+        "iso-stream-http": "~0.1.1",
+        "iso-url": "~0.4.6",
+        "just-kebab-case": "^1.1.0",
+        "just-map-keys": "^1.1.0",
+        "lru-cache": "^5.1.1",
+        "multiaddr": "^6.0.6",
+        "multibase": "~0.6.0",
+        "multicodec": "~0.5.0",
+        "multihashes": "~0.4.14",
+        "ndjson": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
+        "once": "^1.4.0",
+        "peer-id": "~0.12.2",
+        "peer-info": "~0.15.1",
+        "promisify-es6": "^1.0.3",
+        "pull-defer": "~0.2.3",
+        "pull-stream": "^3.6.9",
+        "pull-to-stream": "~0.1.0",
+        "pump": "^3.0.0",
+        "qs": "^6.5.2",
+        "readable-stream": "^3.1.1",
+        "stream-to-pull-stream": "^1.7.2",
+        "tar-stream": "^2.0.1",
+        "through2": "^3.0.1"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+          "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+          "requires": {
+            "lodash": "^4.17.11"
+          }
+        },
+        "bl": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.0.tgz",
+          "integrity": "sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==",
+          "requires": {
+            "readable-stream": "^3.0.1"
+          }
+        },
+        "concat-stream": {
+          "version": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
+          "from": "github:hugomrdias/concat-stream#feat/smaller",
+          "requires": {
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.0.2"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        },
+        "readable-stream": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
+          "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "tar-stream": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.0.1.tgz",
+          "integrity": "sha512-I6OJF7wE62BC6zNPdHDtseK0D0187PBjbKSLYY4ffvVkBM6tyBn2O9plDvVM2229/mozfEL/X3++qSvYYQE2xw==",
+          "requires": {
+            "bl": "^3.0.0",
+            "end-of-stream": "^1.4.1",
+            "fs-constants": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.1.1"
+          }
+        },
+        "through2": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+          "requires": {
+            "readable-stream": "2 || 3"
+          }
+        }
+      }
+    },
+    "ipld-dag-cbor": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.13.1.tgz",
+      "integrity": "sha512-96KKh5XUq9LrWE/TQ/BOJ5FcQx7UZ892N76ufDdovq+fIwZ4/YpPRTAVssLUuN3crATHoGu80TVZMgevsuTCdQ==",
+      "requires": {
+        "borc": "^2.1.0",
+        "bs58": "^4.0.1",
+        "cids": "~0.5.5",
+        "is-circular": "^1.0.2",
+        "multihashes": "~0.4.14",
+        "multihashing-async": "~0.5.1",
+        "traverse": "~0.6.6"
+      }
+    },
+    "ipld-dag-pb": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.15.3.tgz",
+      "integrity": "sha512-J1RJzSVCaOpxPmSzXbwVNsAZPHctjY4OjqG1dMIG86Z37CKvuy1QwCFkDhNccUTcQpF3sXfj5e0ZUyMM035vzg==",
+      "requires": {
+        "async": "^2.6.1",
+        "bs58": "^4.0.1",
+        "cids": "~0.5.4",
+        "class-is": "^1.1.0",
+        "is-ipfs": "~0.6.0",
+        "multihashing-async": "~0.5.1",
+        "protons": "^1.0.1",
+        "pull-stream": "^3.6.9",
+        "pull-traverse": "^1.0.3",
+        "stable": "~0.1.8"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+          "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+          "requires": {
+            "lodash": "^4.17.11"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        }
+      }
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -2652,6 +3070,11 @@
       "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
       "dev": true
     },
+    "is-circular": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-circular/-/is-circular-1.0.2.tgz",
+      "integrity": "sha512-YttjnrswnUYRVJvxCvu8z+PGMUSzC2JttP0OEXezlAEdp3EXzhf7IZ3j0gRAybJBQupedIZFhY61Tga6E0qASA=="
+    },
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
@@ -2674,6 +3097,27 @@
       "dev": true,
       "requires": {
         "number-is-nan": "^1.0.0"
+      }
+    },
+    "is-ip": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-2.0.0.tgz",
+      "integrity": "sha1-aO6gfooKCpTC0IDdZ0xzGrKkYas=",
+      "requires": {
+        "ip-regex": "^2.0.0"
+      }
+    },
+    "is-ipfs": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/is-ipfs/-/is-ipfs-0.6.0.tgz",
+      "integrity": "sha512-q/CO69rN+vbw9eGXGQOAa15zXq+pSyhdKvE7mqvuplDu67LyT3H9t3RyYQvKpueN7dL4f6fbyjEMPp9J3rJ4qA==",
+      "requires": {
+        "bs58": "^4.0.1",
+        "cids": "~0.5.6",
+        "mafmt": "^v6.0.7",
+        "multiaddr": "^6.0.4",
+        "multibase": "~0.6.0",
+        "multihashes": "~0.4.13"
       }
     },
     "is-obj": {
@@ -2718,6 +3162,11 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
+    "is-pull-stream": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/is-pull-stream/-/is-pull-stream-0.0.0.tgz",
+      "integrity": "sha1-o7w9HG0wVRUcRr3m85nv7SFEDKk="
+    },
     "is-regex": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
@@ -2736,8 +3185,7 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-subset": {
       "version": "0.1.1",
@@ -2785,6 +3233,46 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
+    "iso-random-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/iso-random-stream/-/iso-random-stream-1.1.0.tgz",
+      "integrity": "sha512-ywSWt0KrWcsaK0jVoVJIR30rLyjg9Rw3k2Sm/qp+3tdtSV0SNH7L7KilKnENcENOSoJxDFvpt2idvuMMQohdCQ=="
+    },
+    "iso-stream-http": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/iso-stream-http/-/iso-stream-http-0.1.2.tgz",
+      "integrity": "sha512-oHEDNOysIMTNypbg2f1SlydqRBvjl4ZbSE9+0awVxnkx3K2stGTFwB/kpVqnB6UEfF8QD36kAjDwZvqyXBLMnQ==",
+      "requires": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
+          "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "iso-url": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.6.tgz",
+      "integrity": "sha512-YQO7+aIe6l1aSJUKOx+Vrv08DlhZeLFIVfehG2L29KLSEb9RszqPXilxJRVpp57px36BddKR5ZsebacO5qG0tg=="
+    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -2811,6 +3299,11 @@
         "istanbul-lib-coverage": "^2.0.1",
         "semver": "^5.5.0"
       }
+    },
+    "js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -2866,8 +3359,15 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "json-text-sequence": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
+      "integrity": "sha1-py8hfcSvxGKf/1/rME3BvVGi89I=",
+      "requires": {
+        "delimit-stream": "0.1.0"
+      }
     },
     "jsonparse": {
       "version": "1.3.1",
@@ -2894,6 +3394,21 @@
       "requires": {
         "array-includes": "^3.0.3"
       }
+    },
+    "just-kebab-case": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/just-kebab-case/-/just-kebab-case-1.1.0.tgz",
+      "integrity": "sha512-QkuwuBMQ9BQHMUEkAtIA4INLrkmnnveqlFB1oFi09gbU0wBdZo6tTnyxNWMR84zHxBuwK7GLAwqN8nrvVxOLTA=="
+    },
+    "just-map-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/just-map-keys/-/just-map-keys-1.1.0.tgz",
+      "integrity": "sha512-oNKi+4y7fr8lXnhKYpBbCkiwHRVkAnx0VDkCeTDtKKMzGr1Lz1Yym+RSieKUTKim68emC5Yxrb4YmiF9STDO+g=="
+    },
+    "keypair": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/keypair/-/keypair-1.0.1.tgz",
+      "integrity": "sha1-dgNxknCvtlZO04oiCHoG/Jqk6hs="
     },
     "kind-of": {
       "version": "3.2.2",
@@ -2934,6 +3449,77 @@
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
+      }
+    },
+    "libp2p-crypto": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.16.1.tgz",
+      "integrity": "sha512-+fxqy+cDjwOKK4KTj44WQmjPE5ep2eR5uAIQWHl/+RKvRSor3+RAY53VWkAecgAEvjX2AswxBsoCIJK1Qk5aIQ==",
+      "requires": {
+        "asmcrypto.js": "^2.3.2",
+        "asn1.js": "^5.0.1",
+        "async": "^2.6.1",
+        "bn.js": "^4.11.8",
+        "browserify-aes": "^1.2.0",
+        "bs58": "^4.0.1",
+        "iso-random-stream": "^1.1.0",
+        "keypair": "^1.0.1",
+        "libp2p-crypto-secp256k1": "~0.3.0",
+        "multihashing-async": "~0.5.1",
+        "node-forge": "~0.7.6",
+        "pem-jwk": "^2.0.0",
+        "protons": "^1.0.1",
+        "rsa-pem-to-jwk": "^1.1.3",
+        "tweetnacl": "^1.0.0",
+        "ursa-optional": "~0.9.10"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+          "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+          "requires": {
+            "lodash": "^4.17.11"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        },
+        "tweetnacl": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.1.tgz",
+          "integrity": "sha512-kcoMoKTPYnoeS50tzoqjPY3Uv9axeuuFAZY9M/9zFnhoVvRfxz9K29IMPD7jGmt2c8SW7i3gT9WqDl2+nV7p4A=="
+        }
+      }
+    },
+    "libp2p-crypto-secp256k1": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/libp2p-crypto-secp256k1/-/libp2p-crypto-secp256k1-0.3.0.tgz",
+      "integrity": "sha512-+rF3S5p2pzS4JLDwVE6gLWZeaKkpl4NkYwG+0knV6ot29UcRSb73OyCWl07r1h5+g9E3KZC3wpsu+RIK5w8zQA==",
+      "requires": {
+        "async": "^2.6.1",
+        "bs58": "^4.0.1",
+        "multihashing-async": "~0.5.1",
+        "nodeify": "^1.0.1",
+        "safe-buffer": "^5.1.2",
+        "secp256k1": "^3.6.1"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+          "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+          "requires": {
+            "lodash": "^4.17.11"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        }
       }
     },
     "load-json-file": {
@@ -3009,6 +3595,11 @@
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
       "dev": true
     },
+    "looper": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
+      "integrity": "sha1-LvpUw7HLq6m5Su4uWRSwvlf7t0k="
+    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -3034,6 +3625,14 @@
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "requires": {
         "yallist": "^3.0.2"
+      }
+    },
+    "mafmt": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-6.0.7.tgz",
+      "integrity": "sha512-2OG/EGAJZmpZBl7YRT1hD83sZa2gKsUEdegRuURreIOe7B4VeHU1rYYmhgk7BkLzknGL3xGYsDx3bbSgEEzE7g==",
+      "requires": {
+        "multiaddr": "^6.0.4"
       }
     },
     "make-fetch-happen": {
@@ -3075,6 +3674,16 @@
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
       "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
       "dev": true
+    },
+    "md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
     },
     "mem": {
       "version": "1.1.0",
@@ -3198,6 +3807,16 @@
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
     },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+    },
+    "minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -3305,17 +3924,137 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
+    "multiaddr": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-6.0.6.tgz",
+      "integrity": "sha512-nR4s91mi7IKed1jrqUj/4OhZ1VKdAjUG79IuVB5PS6b+qxOZLKPW8nsskHhrfGn4o1Rn1NJWl7znidF/NVQpEA==",
+      "requires": {
+        "bs58": "^4.0.1",
+        "class-is": "^1.1.0",
+        "ip": "^1.1.5",
+        "is-ip": "^2.0.0",
+        "varint": "^5.0.0"
+      }
+    },
+    "multibase": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.0.tgz",
+      "integrity": "sha512-R9bNLQhbD7MsitPm1NeY7w9sDgu6d7cuj25snAWH7k5PSNPSwIQQBpcpj8jx1W96dLbdigZqmUWOdQRMnAmgjA==",
+      "requires": {
+        "base-x": "3.0.4"
+      },
+      "dependencies": {
+        "base-x": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
+          "integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        }
+      }
+    },
+    "multicodec": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.5.0.tgz",
+      "integrity": "sha512-lKsJeT4cKeSq0rVEWhO3oSBgDN4sMY1sNZKlvl68g/ZAahjPS1KIVyF4IqhuYmCdtOyKs4Q4hQ6M0C3iqRnuqQ==",
+      "requires": {
+        "varint": "^5.0.0"
+      }
+    },
+    "multihashes": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.14.tgz",
+      "integrity": "sha512-V/g/EIN6nALXfS/xHUAgtfPP3mn3sPIF/i9beuGKf25QXS2QZYCpeVJbDPEannkz32B2fihzCe2D/KMrbcmefg==",
+      "requires": {
+        "bs58": "^4.0.1",
+        "varint": "^5.0.0"
+      }
+    },
+    "multihashing-async": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.5.2.tgz",
+      "integrity": "sha512-mmyG6M/FKxrpBh9xQDUvuJ7BbqT93ZeEeH5X6LeMYKoYshYLr9BDdCsvDtZvn+Egf+/Xi+aOznrWL4vp3s+p0Q==",
+      "requires": {
+        "blakejs": "^1.1.0",
+        "js-sha3": "~0.8.0",
+        "multihashes": "~0.4.13",
+        "murmurhash3js": "^3.0.1",
+        "nodeify": "^1.0.1"
+      }
+    },
+    "murmurhash3js": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/murmurhash3js/-/murmurhash3js-3.0.1.tgz",
+      "integrity": "sha1-Ppg+W0fCoG9DpxMXTn5DXKBEuZg="
+    },
     "mute-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
+    "nan": {
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+      "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "ndjson": {
+      "version": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
+      "from": "github:hugomrdias/ndjson#feat/readable-stream3",
+      "requires": {
+        "json-stringify-safe": "^5.0.1",
+        "minimist": "^1.2.0",
+        "split2": "^3.1.0",
+        "through2": "^3.0.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "readable-stream": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "split2": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/split2/-/split2-3.1.1.tgz",
+          "integrity": "sha512-emNzr1s7ruq4N+1993yht631/JH+jaj0NYBosuKmLcq+JkGQ9MmTw1RB1fGaTCzUuseRIClrlSLHRNYGwWQ58Q==",
+          "requires": {
+            "readable-stream": "^3.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
+          "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "through2": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+          "requires": {
+            "readable-stream": "2 || 3"
+          }
+        }
+      }
     },
     "nice-try": {
       "version": "1.0.5",
@@ -3348,6 +4087,27 @@
         "encoding": "^0.1.11",
         "json-parse-better-errors": "^1.0.0",
         "safe-buffer": "^5.1.1"
+      }
+    },
+    "node-forge": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
+      "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw=="
+    },
+    "nodeify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/nodeify/-/nodeify-1.0.1.tgz",
+      "integrity": "sha1-ZKtpp7268DzhB7TwM1yHwLnpGx0=",
+      "requires": {
+        "is-promise": "~1.0.0",
+        "promise": "~1.3.0"
+      },
+      "dependencies": {
+        "is-promise": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz",
+          "integrity": "sha1-MVc3YcBX4zwukaq56W2gjO++duU="
+        }
       }
     },
     "normalize-package-data": {
@@ -4835,6 +5595,51 @@
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
     },
+    "peer-id": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.12.2.tgz",
+      "integrity": "sha512-pked3yPLcOcprH21OnYbJAzk9OgI/TDEqjJ0IfRJSVB/61ZyqU5VKO7cw7hul+YD8nTD79wM79xFRWN3f6otNg==",
+      "requires": {
+        "async": "^2.6.1",
+        "class-is": "^1.1.0",
+        "libp2p-crypto": "~0.16.0",
+        "multihashes": "~0.4.13"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+          "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+          "requires": {
+            "lodash": "^4.17.11"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        }
+      }
+    },
+    "peer-info": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.15.1.tgz",
+      "integrity": "sha512-Y91Q2tZRC0CpSTPd1UebhGqniOrOAk/aj60uYUcWJXCoLTAnGu+4LJGoiay8ayudS6ice7l3SKhgL/cS62QacA==",
+      "requires": {
+        "mafmt": "^6.0.2",
+        "multiaddr": "^6.0.3",
+        "peer-id": "~0.12.2",
+        "unique-by": "^1.0.0"
+      }
+    },
+    "pem-jwk": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pem-jwk/-/pem-jwk-2.0.0.tgz",
+      "integrity": "sha512-rFxu7rVoHgQ5H9YsP50dDWf0rHjreVA2z0yPiWr5WdH/UHb29hKtF7h6l8vNd1cbYR1t0QL+JKhW55a2ZV4KtA==",
+      "requires": {
+        "asn1.js": "^5.0.1"
+      }
+    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -4954,6 +5759,21 @@
       "integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==",
       "dev": true
     },
+    "promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-1.3.0.tgz",
+      "integrity": "sha1-5cyaTIJ45GZP/twBx9qEhCsEAXU=",
+      "requires": {
+        "is-promise": "~1"
+      },
+      "dependencies": {
+        "is-promise": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz",
+          "integrity": "sha1-MVc3YcBX4zwukaq56W2gjO++duU="
+        }
+      }
+    },
     "promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -4967,6 +5787,11 @@
         "err-code": "^1.0.0",
         "retry": "^0.10.0"
       }
+    },
+    "promisify-es6": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/promisify-es6/-/promisify-es6-1.0.3.tgz",
+      "integrity": "sha512-N9iVG+CGJsI4b4ZGazjwLnxErD2d9Pe4DPvvXSxYA9tFNu8ymXME4Qs5HIQ0LMJpNM7zj+m0NlNnNeqFpKzqnA=="
     },
     "prop-types": {
       "version": "15.6.2",
@@ -4984,12 +5809,28 @@
       "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=",
       "dev": true
     },
+    "protocol-buffers-schema": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.3.2.tgz",
+      "integrity": "sha512-Xdayp8sB/mU+sUV4G7ws8xtYMGdQnxbeIfLjyO9TZZRJdztBGhlmbI5x1qcY4TG5hBkIKGnc28i7nXxaugu88w=="
+    },
     "protoduck": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/protoduck/-/protoduck-5.0.1.tgz",
       "integrity": "sha512-WxoCeDCoCBY55BMvj4cAEjdVUFGRWed9ZxPlqTKYyw1nDDTQ4pqmnIMAGfJlg7Dx35uB/M+PHJPTmGOvaCaPTg==",
       "requires": {
         "genfun": "^5.0.0"
+      }
+    },
+    "protons": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/protons/-/protons-1.0.1.tgz",
+      "integrity": "sha512-+0ZKnfVs+4c43tbAQ5j0Mck8wPcLnlxUYzKQoB4iDW4ocdXGnN4P+0dDbgX1FTpoY9+7P2Tn2scJyHHqj+S/lQ==",
+      "requires": {
+        "protocol-buffers-schema": "^3.3.1",
+        "safe-buffer": "^5.1.1",
+        "signed-varint": "^2.0.1",
+        "varint": "^5.0.0"
       }
     },
     "pseudomap": {
@@ -5002,6 +5843,49 @@
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
       "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
       "dev": true
+    },
+    "pull-defer": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.3.tgz",
+      "integrity": "sha512-/An3KE7mVjZCqNhZsr22k1Tx8MACnUnHZZNPSJ0S62td8JtYr/AiRG42Vz7Syu31SoTLUzVIe61jtT/pNdjVYA=="
+    },
+    "pull-stream": {
+      "version": "3.6.9",
+      "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.9.tgz",
+      "integrity": "sha512-hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw=="
+    },
+    "pull-to-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/pull-to-stream/-/pull-to-stream-0.1.0.tgz",
+      "integrity": "sha512-LMvdE0JwT7XQZMFjc7JDl/G9gmoZ8Zo8e86SG4ZZUcjuwvod803KxpAK8WrmdxzHsMRK9DETlIzuA0tbEVv6jg==",
+      "requires": {
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
+          "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "pull-traverse": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pull-traverse/-/pull-traverse-1.0.3.tgz",
+      "integrity": "sha1-dPtde+f6a9enjpeTPhmbeUWGaTg="
     },
     "pump": {
       "version": "3.0.0",
@@ -5048,8 +5932,7 @@
     "qs": {
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.6.0.tgz",
-      "integrity": "sha512-KIJqT9jQJDQx5h5uAVPimw6yVg2SekOKu959OCtktD3FjzbpvaPr8i4zzg07DOMz+igA4W/aNM7OV8H37pFYfA==",
-      "dev": true
+      "integrity": "sha512-KIJqT9jQJDQx5h5uAVPimw6yVg2SekOKu959OCtktD3FjzbpvaPr8i4zzg07DOMz+igA4W/aNM7OV8H37pFYfA=="
     },
     "quick-lru": {
       "version": "1.1.0",
@@ -5271,6 +6154,54 @@
         "glob": "^7.0.5"
       }
     },
+    "ripemd160": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
+      }
+    },
+    "rsa-pem-to-jwk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/rsa-pem-to-jwk/-/rsa-pem-to-jwk-1.1.3.tgz",
+      "integrity": "sha1-JF52vbfnI0z+58oDLTG1TDj6uY4=",
+      "requires": {
+        "object-assign": "^2.0.0",
+        "rsa-unpack": "0.0.6"
+      },
+      "dependencies": {
+        "object-assign": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
+        }
+      }
+    },
+    "rsa-unpack": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/rsa-unpack/-/rsa-unpack-0.0.6.tgz",
+      "integrity": "sha1-9Q69VqYoN45jHylxYQJs6atO3bo=",
+      "requires": {
+        "optimist": "~0.3.5"
+      },
+      "dependencies": {
+        "optimist": {
+          "version": "0.3.7",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+          "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
+          "requires": {
+            "wordwrap": "~0.0.2"
+          }
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+        }
+      }
+    },
     "run-async": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
@@ -5314,6 +6245,21 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "secp256k1": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.6.2.tgz",
+      "integrity": "sha512-90nYt7yb0LmI4A2jJs1grglkTAXrBwxYAjP9bpeKjvJKOjG2fOeH/YI/lchDMIvjrOasd5QXwvV2jwN168xNng==",
+      "requires": {
+        "bindings": "^1.2.1",
+        "bip66": "^1.1.3",
+        "bn.js": "^4.11.3",
+        "create-hash": "^1.1.2",
+        "drbg.js": "^1.0.1",
+        "elliptic": "^6.2.3",
+        "nan": "^2.2.1",
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "semver": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
@@ -5324,6 +6270,15 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
+    },
+    "sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -5345,6 +6300,14 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
+    },
+    "signed-varint": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/signed-varint/-/signed-varint-2.0.1.tgz",
+      "integrity": "sha1-UKmYnafJjCxh2tEZvJdHDvhSgSk=",
+      "requires": {
+        "varint": "~5.0.0"
+      }
     },
     "slice-ansi": {
       "version": "1.0.0",
@@ -5490,6 +6453,11 @@
         "figgy-pudding": "^3.5.1"
       }
     },
+    "stable": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+      "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
+    },
     "stack-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
@@ -5562,6 +6530,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+    },
+    "stream-to-pull-stream": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.3.tgz",
+      "integrity": "sha512-6sNyqJpr5dIOQdgNy/xcDWwDuzAsAwVzhzrWlAPAQ7Lkjx/rv0wgvxEyKwTq6FmNd5rjTrELt/CLmaSw7crMGg==",
+      "requires": {
+        "looper": "^3.0.0",
+        "pull-stream": "^3.2.3"
+      }
     },
     "string-width": {
       "version": "1.0.2",
@@ -6064,6 +7041,11 @@
         "punycode": "^1.4.1"
       }
     },
+    "traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
+    },
     "trim-newlines": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
@@ -6193,6 +7175,11 @@
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
       "dev": true
     },
+    "unique-by": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-by/-/unique-by-1.0.0.tgz",
+      "integrity": "sha1-UiDIa6e8Vy+3E610ZRRwy2RCEr0="
+    },
     "unique-filename": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
@@ -6226,6 +7213,15 @@
         }
       }
     },
+    "ursa-optional": {
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/ursa-optional/-/ursa-optional-0.9.10.tgz",
+      "integrity": "sha512-RvEbhnxlggX4MXon7KQulTFiJQtLJZpSb9ZSa7ZTkOW0AzqiVTaLjI4vxaSzJBDH9dwZ3ltZadFiBaZslp6haA==",
+      "requires": {
+        "bindings": "^1.3.0",
+        "nan": "^2.11.1"
+      }
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -6253,6 +7249,11 @@
       "requires": {
         "builtins": "^1.0.3"
       }
+    },
+    "varint": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.0.tgz",
+      "integrity": "sha1-2Ca4n3SQcy+rwMDtaT7Uddyynr8="
     },
     "verror": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "figgy-pudding": "^3.5.1",
     "get-stream": "^4.1.0",
     "glob": "^7.1.3",
+    "ipfs-http-client": "^30.1.1",
     "lru-cache": "^5.1.1",
     "make-fetch-happen": "^4.0.1",
     "minimatch": "^3.0.4",

--- a/test/ipfs.js
+++ b/test/ipfs.js
@@ -1,0 +1,111 @@
+'use strict'
+
+const clearMemoized = require('..').clearMemoized
+const npmlog = require('npmlog')
+const test = require('tap').test
+const testDir = require('./util/test-dir')
+const tnock = require('./util/tnock')
+const path = require('path')
+const fs = require('fs')
+const CACHE = testDir(__filename)
+const packument = require('../packument')
+const manifest = require('../manifest')
+const tarball = require('../tarball')
+
+npmlog.level = process.env.LOGLEVEL || 'silent'
+const OPTS = {
+  cache: CACHE,
+  registry: 'https://mock.reg',
+  log: npmlog,
+  retry: {
+    retries: 1,
+    factor: 1,
+    minTimeout: 1,
+    maxTimeout: 10
+  },
+  'ipfs-url': '/ip4/127.0.0.1/tcp/1234'
+}
+
+test('packument is unimplemented', t => {
+  clearMemoized()
+
+  return packument('ipfs://zdj7WhFBRwsWJJxzE7bBbFn5pLb3VfTLThfavMrdF9gNqbvxF', OPTS)
+    .then(() => {
+      throw new Error('this was not supposed to succeed')
+    })
+    .catch(err => {
+      t.ok(err, 'correctly errored')
+      t.notMatch(err.message, /not supposed to succeed/)
+      t.match(err.message, /Not implemented/)
+    })
+})
+
+test('resolves manifest from tarball', t => {
+  clearMemoized()
+  const srv = tnock(t, 'http://127.0.0.1:1234')
+  const file = fs.readFileSync(path.resolve(__dirname, './fixtures/no-shrinkwrap.tgz'))
+
+  srv.post('/api/v0/cat?arg=zdj7WhFBRwsWJJxzE7bBbFn5pLb3VfTLThfavMrdF9gNqbvxF&stream-channels=true')
+    .once()
+    .reply(200, file, {
+      'x-stream-output': 1,
+      'x-content-length': file.length,
+      'transfer-encoding': 'chunked',
+      trailer: 'X-Stream-Error'
+    })
+
+  return manifest('ipfs://zdj7WhFBRwsWJJxzE7bBbFn5pLb3VfTLThfavMrdF9gNqbvxF', OPTS)
+    .then((manifest) => {
+      t.equal(manifest.version, '1.0.0')
+    })
+})
+
+test('resolves a tarball from a CID', t => {
+  clearMemoized()
+  const srv = tnock(t, 'http://127.0.0.1:1234')
+  const file = fs.readFileSync(path.resolve(__dirname, './fixtures/no-shrinkwrap.tgz'))
+
+  srv.post('/api/v0/cat?arg=zdj7WhFBRwsWJJxzE7bBbFn5pLb3VfTLThfavMrdF9gNqbvxF&stream-channels=true')
+    .once()
+    .reply(200, file, {
+      'x-stream-output': 1,
+      'x-content-length': file.length,
+      'transfer-encoding': 'chunked',
+      trailer: 'X-Stream-Error'
+    })
+
+  return tarball('ipfs://zdj7WhFBRwsWJJxzE7bBbFn5pLb3VfTLThfavMrdF9gNqbvxF', OPTS)
+    .then(buf => {
+      t.true(Buffer.isBuffer(buf), 'Fetched tarball')
+      t.equal(file.length, buf.length, 'Fetched tarball')
+    })
+})
+
+test('errors if no IPFS URL is specified', t => {
+  clearMemoized()
+
+  return tarball('ipfs://zdj7WhFBRwsWJJxzE7bBbFn5pLb3VfTLThfavMrdF9gNqbvxF', {
+    'ipfs-url': null
+  })
+    .then(() => {
+      throw new Error('this was not supposed to succeed')
+    })
+    .catch(err => {
+      t.ok(err, 'correctly errored')
+      t.notMatch(err.message, /not supposed to succeed/)
+      t.equal(err.code, 'ENOIPFSURL', 'no IPFS URL was specified')
+    })
+})
+
+test('throws an error if CID is invalid', t => {
+  clearMemoized()
+
+  return tarball('ipfs://not-a-valid-cid', OPTS)
+    .then(() => {
+      throw new Error('this was not supposed to succeed')
+    })
+    .catch(err => {
+      t.ok(err, 'correctly errored')
+      t.notMatch(err.message, /not supposed to succeed/)
+    })
+})

--- a/test/ipns.js
+++ b/test/ipns.js
@@ -1,0 +1,347 @@
+'use strict'
+
+const clearMemoized = require('..').clearMemoized
+const npmlog = require('npmlog')
+const test = require('tap').test
+const testDir = require('./util/test-dir')
+const tnock = require('./util/tnock')
+const path = require('path')
+const fs = require('fs')
+const CACHE = testDir(__filename)
+const packument = require('../packument')
+const manifest = require('../manifest')
+const tarball = require('../tarball')
+
+const MANIFEST = {
+  '_id': 'express',
+  '_rev': '1032-3bae071fc67636b1c05ae7c9ebbe64e1',
+  'name': 'express',
+  'description': 'Fast, unopinionated, minimalist web framework',
+  'dist-tags': {
+    'latest': '3.2.0',
+    'next': '4.0.0'
+  },
+  'versions': {
+    '0.0.1': {
+      'name': 'some-module',
+      'version': '0.0.1',
+      'dist': {
+        'integrity': 'sha512-3FW+yXzYCViXf6Ty9TN9IKLW+rC8qok3ktS4hS1FILAEnMnfnDpQ+23rZVvWC0Ul1alYpJXx7xSBSBp073970g==',
+        'shasum': '879bfb1bd52834646a9d8c3a773863c36e4d494c',
+        'tarball': 'https://registry.npmjs.com/some-module/-/some-module-0.0.1.tgz',
+        'cid': 'bafybeifprvl6iqk3oj6a5yw74v5ggmdc7orhyibcz437kdont5tuj7pjfa'
+      }
+    },
+    '1.0.0': {
+      'name': 'some-module',
+      'version': '1.0.0',
+      'dist': {
+        'integrity': 'sha512-3FW+yXzYCViXf6Ty9TN9IKLW+rC8qok3ktS4hS1FILAEnMnfnDpQ+23rZVvWC0Ul1alYpJXx7xSBSBp073970g==',
+        'shasum': '879bfb1bd52834646a9d8c3a773863c36e4d494c',
+        'tarball': 'https://registry.npmjs.com/some-module/-/some-module-1.0.0.tgz',
+        'cid': 'bafybeifprvl6iqk3oj6a5yw74v5ggmdc7orhyibcz437kdont5tuj7pjfb'
+      }
+    },
+    '1.1.0': {
+      'name': 'some-module',
+      'version': '1.1.0',
+      'dist': {
+        'integrity': 'sha512-3FW+yXzYCViXf6Ty9TN9IKLW+rC8qok3ktS4hS1FILAEnMnfnDpQ+23rZVvWC0Ul1alYpJXx7xSBSBp073970g==',
+        'shasum': '879bfb1bd52834646a9d8c3a773863c36e4d494c',
+        'tarball': 'https://registry.npmjs.com/some-module/-/some-module-1.1.0.tgz',
+        'cid': 'bafybeifprvl6iqk3oj6a5yw74v5ggmdc7orhyibcz437kdont5tuj7pjfc'
+      }
+    },
+    '2.0.0': {
+      'name': 'some-module',
+      'version': '2.0.0',
+      'dist': {
+        'integrity': 'sha512-3FW+yXzYCViXf6Ty9TN9IKLW+rC8qok3ktS4hS1FILAEnMnfnDpQ+23rZVvWC0Ul1alYpJXx7xSBSBp073970g==',
+        'shasum': '879bfb1bd52834646a9d8c3a773863c36e4d494c',
+        'tarball': 'https://registry.npmjs.com/some-module/-/some-module-2.0.0.tgz'
+      }
+    },
+    '3.2.0': {
+      'name': 'some-module',
+      'version': '3.2.0',
+      'dist': {
+        'integrity': 'sha512-3FW+yXzYCViXf6Ty9TN9IKLW+rC8qok3ktS4hS1FILAEnMnfnDpQ+23rZVvWC0Ul1alYpJXx7xSBSBp073970g==',
+        'shasum': '879bfb1bd52834646a9d8c3a773863c36e4d494c',
+        'tarball': 'https://registry.npmjs.com/some-module/-/some-module-1.1.0.tgz',
+        'cid': 'bafybeifprvl6iqk3oj6a5yw74v5ggmdc7orhyibcz437kdont5tuj7pjfd'
+      }
+    },
+    '4.0.0': {
+      'name': 'some-module',
+      'version': '4.0.0',
+      'dist': {
+        'integrity': 'sha512-3FW+yXzYCViXf6Ty9TN9IKLW+rC8qok3ktS4hS1FILAEnMnfnDpQ+23rZVvWC0Ul1alYpJXx7xSBSBp073970g==',
+        'shasum': '879bfb1bd52834646a9d8c3a773863c36e4d494c',
+        'tarball': 'https://registry.npmjs.com/some-module/-/some-module-1.1.0.tgz',
+        'cid': 'bafybeifprvl6iqk3oj6a5yw74v5ggmdc7orhyibcz437kdont5tuj7pjfe'
+      }
+    }
+  }
+}
+
+npmlog.level = process.env.LOGLEVEL || 'silent'
+const OPTS = {
+  cache: CACHE,
+  registry: 'https://mock.reg',
+  log: npmlog,
+  retry: {
+    retries: 1,
+    factor: 1,
+    minTimeout: 1,
+    maxTimeout: 10
+  },
+  'ipfs-url': '/ip4/127.0.0.1/tcp/1234'
+}
+
+test('returns a packument from an IPNS name', t => {
+  clearMemoized()
+  const srv = tnock(t, 'http://127.0.0.1:1234')
+
+  srv.post('/api/v0/name/resolve?arg=QmZfVvXNWwwYcbMikEHwJSt2SGg3tEWs45MBeUsdChBArF&stream-channels=true')
+    .once()
+    .reply(200, {
+      Path: '/ipfs/QmZfVvXNWwwYcbMikEHwJSt2SGg3tEWs45MBeUsdChBArF'
+    })
+  srv.post('/api/v0/cat?arg=%2Fipfs%2FQmZfVvXNWwwYcbMikEHwJSt2SGg3tEWs45MBeUsdChBArF&stream-channels=true')
+    .once()
+    .reply(200, MANIFEST, {
+      'x-stream-output': 1,
+      'x-content-length': JSON.stringify(MANIFEST).length,
+      'transfer-encoding': 'chunked',
+      trailer: 'X-Stream-Error'
+    })
+
+  return packument('ipns://QmZfVvXNWwwYcbMikEHwJSt2SGg3tEWs45MBeUsdChBArF#^1.0.0', OPTS)
+    .then(packument => {
+      t.deepequal(packument, MANIFEST, 'Retrieved packument')
+    })
+})
+
+test('resolves a manifest from an IPNS name', t => {
+  clearMemoized()
+  const srv = tnock(t, 'http://127.0.0.1:1234')
+
+  srv.post('/api/v0/name/resolve?arg=QmZfVvXNWwwYcbMikEHwJSt2SGg3tEWs45MBeUsdChBArF&stream-channels=true')
+    .once()
+    .reply(200, {
+      Path: '/ipfs/QmZfVvXNWwwYcbMikEHwJSt2SGg3tEWs45MBeUsdChBArF'
+    })
+  srv.post('/api/v0/cat?arg=%2Fipfs%2FQmZfVvXNWwwYcbMikEHwJSt2SGg3tEWs45MBeUsdChBArF&stream-channels=true')
+    .once()
+    .reply(200, MANIFEST, {
+      'x-stream-output': 1,
+      'x-content-length': JSON.stringify(MANIFEST).length,
+      'transfer-encoding': 'chunked',
+      trailer: 'X-Stream-Error'
+    })
+  srv.post('/api/v0/cat?arg=%2Fipfs%2Fbafybeifprvl6iqk3oj6a5yw74v5ggmdc7orhyibcz437kdont5tuj7pjfc&stream-channels=true')
+    .once()
+    .reply(200, Buffer.from([0, 1, 2, 3]), {
+      'x-stream-output': 1,
+      'x-content-length': 4,
+      'transfer-encoding': 'chunked',
+      trailer: 'X-Stream-Error'
+    })
+
+  return manifest('ipns://QmZfVvXNWwwYcbMikEHwJSt2SGg3tEWs45MBeUsdChBArF#^1.0.0', OPTS)
+    .then(pkg => {
+      t.equal(pkg.version, '1.1.0', 'Retrieved latest version')
+    })
+})
+
+test('fetches a tarball from an IPNS name', t => {
+  clearMemoized()
+  const srv = tnock(t, 'http://127.0.0.1:1234')
+  const file = fs.readFileSync(path.resolve(__dirname, './fixtures/no-shrinkwrap.tgz'))
+
+  srv.post('/api/v0/name/resolve?arg=QmZfVvXNWwwYcbMikEHwJSt2SGg3tEWs45MBeUsdChBArF&stream-channels=true')
+    .once()
+    .reply(200, {
+      Path: '/ipfs/QmZfVvXNWwwYcbMikEHwJSt2SGg3tEWs45MBeUsdChBArF'
+    })
+  srv.post('/api/v0/cat?arg=%2Fipfs%2FQmZfVvXNWwwYcbMikEHwJSt2SGg3tEWs45MBeUsdChBArF&stream-channels=true')
+    .once()
+    .reply(200, MANIFEST, {
+      'x-stream-output': 1,
+      'x-content-length': JSON.stringify(MANIFEST).length,
+      'transfer-encoding': 'chunked',
+      trailer: 'X-Stream-Error'
+    })
+  srv.post('/api/v0/cat?arg=%2Fipfs%2Fbafybeifprvl6iqk3oj6a5yw74v5ggmdc7orhyibcz437kdont5tuj7pjfc&stream-channels=true')
+    .once()
+    .reply(200, file, {
+      'x-stream-output': 1,
+      'x-content-length': file.length,
+      'transfer-encoding': 'chunked',
+      trailer: 'X-Stream-Error'
+    })
+
+  return tarball('ipns://QmZfVvXNWwwYcbMikEHwJSt2SGg3tEWs45MBeUsdChBArF#^1.0.0', OPTS)
+    .then(buf => {
+      t.ok(Buffer.isBuffer(buf), 'Fetched a tarball')
+      t.equal(file.length, buf.length, 'Fetched tarball')
+    })
+})
+
+test('caches IPNS lookups', t => {
+  clearMemoized()
+  const srv = tnock(t, 'http://127.0.0.1:1234')
+
+  srv.post('/api/v0/name/resolve?arg=QmZfVvXNWwwYcbMikEHwJSt2SGg3tEWs45MBeUsdChBArF&stream-channels=true')
+    .once()
+    .reply(200, {
+      Path: '/ipfs/QmZfVvXNWwwYcbMikEHwJSt2SGg3tEWs45MBeUsdChBArF'
+    })
+  srv.post('/api/v0/cat?arg=%2Fipfs%2FQmZfVvXNWwwYcbMikEHwJSt2SGg3tEWs45MBeUsdChBArF&stream-channels=true')
+    .once()
+    .reply(200, MANIFEST, {
+      'x-stream-output': 1,
+      'x-content-length': JSON.stringify(MANIFEST).length,
+      'transfer-encoding': 'chunked',
+      trailer: 'X-Stream-Error'
+    })
+  srv.post('/api/v0/cat?arg=%2Fipfs%2FQmZfVvXNWwwYcbMikEHwJSt2SGg3tEWs45MBeUsdChBArF&stream-channels=true')
+    .once()
+    .reply(200, MANIFEST, {
+      'x-stream-output': 1,
+      'x-content-length': JSON.stringify(MANIFEST).length,
+      'transfer-encoding': 'chunked',
+      trailer: 'X-Stream-Error'
+    })
+  srv.post('/api/v0/cat?arg=%2Fipfs%2Fbafybeifprvl6iqk3oj6a5yw74v5ggmdc7orhyibcz437kdont5tuj7pjfc&stream-channels=true')
+    .once()
+    .reply(200, Buffer.from([0, 1, 2, 3]), {
+      'x-stream-output': 1,
+      'x-content-length': 4,
+      'transfer-encoding': 'chunked',
+      trailer: 'X-Stream-Error'
+    })
+  srv.post('/api/v0/cat?arg=%2Fipfs%2Fbafybeifprvl6iqk3oj6a5yw74v5ggmdc7orhyibcz437kdont5tuj7pjfc&stream-channels=true')
+    .once()
+    .reply(200, Buffer.from([0, 1, 2, 3]), {
+      'x-stream-output': 1,
+      'x-content-length': 4,
+      'transfer-encoding': 'chunked',
+      trailer: 'X-Stream-Error'
+    })
+
+  return manifest('ipns://QmZfVvXNWwwYcbMikEHwJSt2SGg3tEWs45MBeUsdChBArF#^1.0.0', OPTS)
+    .then(() => manifest('ipns://QmZfVvXNWwwYcbMikEHwJSt2SGg3tEWs45MBeUsdChBArF#^1.0.0', OPTS))
+})
+
+test('throws an error if IPNS name is invalid', t => {
+  clearMemoized()
+  const srv = tnock(t, 'http://127.0.0.1:1234')
+  srv.post('/api/v0/name/resolve?arg=not&stream-channels=true')
+    .once()
+    .reply(500, {
+      Message: 'not a valid proquint string',
+      Code: 0,
+      Type: 'error'
+    })
+
+  return manifest('ipns://not-a-valid-cid', OPTS)
+    .then(() => {
+      throw new Error('this was not supposed to succeed')
+    })
+    .catch(err => {
+      t.ok(err, 'correctly errored')
+      t.notMatch(err.message, /not supposed to succeed/)
+      t.match(err.message, 'not a valid proquint string')
+    })
+})
+
+test('throws an error if no CID is available for the requested version', t => {
+  clearMemoized()
+  const srv = tnock(t, 'http://127.0.0.1:1234')
+  srv.post('/api/v0/name/resolve?arg=QmZfVvXNWwwYcbMikEHwJSt2SGg3tEWs45MBeUsdChBArF&stream-channels=true')
+    .once()
+    .reply(200, {
+      Path: '/ipfs/QmZfVvXNWwwYcbMikEHwJSt2SGg3tEWs45MBeUsdChBArF'
+    })
+  srv.post('/api/v0/cat?arg=%2Fipfs%2FQmZfVvXNWwwYcbMikEHwJSt2SGg3tEWs45MBeUsdChBArF&stream-channels=true')
+    .once()
+    .reply(200, MANIFEST, {
+      'x-stream-output': 1,
+      'x-content-length': JSON.stringify(MANIFEST).length,
+      'transfer-encoding': 'chunked',
+      trailer: 'X-Stream-Error'
+    })
+
+  return manifest('ipns://QmZfVvXNWwwYcbMikEHwJSt2SGg3tEWs45MBeUsdChBArF#2.0.0', OPTS)
+    .then(() => {
+      throw new Error('this was not supposed to succeed')
+    })
+    .catch(err => {
+      t.ok(err, 'correctly errored')
+      t.notMatch(err.message, /not supposed to succeed/)
+      t.match(err.code, 'ENOCID')
+    })
+})
+
+test('resolves the latest version available if no version is specified', t => {
+  clearMemoized()
+  const srv = tnock(t, 'http://127.0.0.1:1234')
+  srv.post('/api/v0/name/resolve?arg=QmZfVvXNWwwYcbMikEHwJSt2SGg3tEWs45MBeUsdChBArF&stream-channels=true')
+    .once()
+    .reply(200, {
+      Path: '/ipfs/QmZfVvXNWwwYcbMikEHwJSt2SGg3tEWs45MBeUsdChBArF'
+    })
+  srv.post('/api/v0/cat?arg=%2Fipfs%2FQmZfVvXNWwwYcbMikEHwJSt2SGg3tEWs45MBeUsdChBArF&stream-channels=true')
+    .once()
+    .reply(200, MANIFEST, {
+      'x-stream-output': 1,
+      'x-content-length': JSON.stringify(MANIFEST).length,
+      'transfer-encoding': 'chunked',
+      trailer: 'X-Stream-Error'
+    })
+  srv.post('/api/v0/cat?arg=%2Fipfs%2Fbafybeifprvl6iqk3oj6a5yw74v5ggmdc7orhyibcz437kdont5tuj7pjfd&stream-channels=true')
+    .once()
+    .reply(200, Buffer.from([0, 1, 2, 3]), {
+      'x-stream-output': 1,
+      'x-content-length': 4,
+      'transfer-encoding': 'chunked',
+      trailer: 'X-Stream-Error'
+    })
+
+  return manifest('ipns://QmZfVvXNWwwYcbMikEHwJSt2SGg3tEWs45MBeUsdChBArF', OPTS)
+    .then((manifest) => {
+      t.equal(manifest.version, '3.2.0')
+    })
+})
+
+test('resolves the versions by tag', t => {
+  clearMemoized()
+  const srv = tnock(t, 'http://127.0.0.1:1234')
+  srv.post('/api/v0/name/resolve?arg=QmZfVvXNWwwYcbMikEHwJSt2SGg3tEWs45MBeUsdChBArF&stream-channels=true')
+    .once()
+    .reply(200, {
+      Path: '/ipfs/QmZfVvXNWwwYcbMikEHwJSt2SGg3tEWs45MBeUsdChBArF'
+    })
+  srv.post('/api/v0/cat?arg=%2Fipfs%2FQmZfVvXNWwwYcbMikEHwJSt2SGg3tEWs45MBeUsdChBArF&stream-channels=true')
+    .once()
+    .reply(200, MANIFEST, {
+      'x-stream-output': 1,
+      'x-content-length': JSON.stringify(MANIFEST).length,
+      'transfer-encoding': 'chunked',
+      trailer: 'X-Stream-Error'
+    })
+  srv.post('/api/v0/cat?arg=%2Fipfs%2Fbafybeifprvl6iqk3oj6a5yw74v5ggmdc7orhyibcz437kdont5tuj7pjfe&stream-channels=true')
+    .once()
+    .reply(200, Buffer.from([0, 1, 2, 3]), {
+      'x-stream-output': 1,
+      'x-content-length': 4,
+      'transfer-encoding': 'chunked',
+      trailer: 'X-Stream-Error'
+    })
+
+  return manifest('ipns://QmZfVvXNWwwYcbMikEHwJSt2SGg3tEWs45MBeUsdChBArF#next', OPTS)
+    .then((manifest) => {
+      t.equal(manifest.version, '4.0.0')
+    })
+})


### PR DESCRIPTION
This PR has come together following [our conversation on Twitter](https://twitter.com/maybekatz/status/1113118833483579392).

It adds support for resolving tarballs with [CIDs](https://docs.ipfs.io/guides/concepts/cid/) or packuments with [IPNS names](https://docs.ipfs.io/guides/concepts/ipns/).

So a users' `package.json` would be able to contain this sort of thing:

```javascript
{
  "name": "my-module",
  // ...
  "dependencies": {
    "express": "ipfs://Qmfoo",
    "hapi": "ipns://QmFoo#^18.0.0",
    "http-server": "^0.11.0"
  }
}
```

Here `express` is essentially doing something similar to`"express": "https://example.com/some-tarball.tgz"` whereas `hapi` is using an IPNS name that would resolve to a packument and the semver range `^18.0.0` would be resolved from that packument and for `http-server`, the npm cli would talk to the public registry as normal.

To prevent the need to bundle IPFS with npm it uses [`ipfs-http-client`](https://www.npmjs.com/package/ipfs-http-client), the idea is that the user would already be running an IPFS node (perhaps through [IPFS Desktop](https://github.com/ipfs-shipyard/ipfs-desktop) or a [normal install](https://docs.ipfs.io/introduction/install/)).  They can then either specify the API port on each invocation with `--ipfs-url=http://localhost:5001` or just once with `npm config set ipfs-url http://localhost:5001`.

I'd love to know what you think & work through any required changes, etc.