### PR TITLE
Ensure that stream failures are sent up the promise chain

### DIFF
--- a/test/git.extract.js
+++ b/test/git.extract.js
@@ -1,0 +1,41 @@
+'use strict'
+
+const BB = require('bluebird')
+const fs = BB.promisifyAll(require('fs'))
+const mkdirp = BB.promisify(require('mkdirp'))
+const npmlog = require('npmlog')
+const path = require('path')
+const test = require('tap').test
+
+const testDir = require('./util/test-dir')(__filename)
+
+const extract = require('../extract.js')
+
+npmlog.level = process.env.LOGLEVEL || 'silent'
+const OPTS = {
+  git: 'git',
+  cache: path.join(testDir, 'cache'),
+  log: npmlog,
+  registry: 'https://my.mock.registry/',
+  retry: false
+}
+
+test('extracting a git target reports failures', t => {
+  const oldPath = process.env.PATH
+  process.env.PATH = ''
+  const dest = path.join(testDir, 'foo')
+  return mkdirp(dest)
+    .then(() => fs.writeFileAsync(path.join(dest, 'q'), 'foo'))
+    .then(() => extract('github:zkat/pacote', dest,
+      Object.assign({}, OPTS)))
+    .finally(() => {
+      process.env.PATH = oldPath
+    })
+    .then(() => {
+      t.fail('the promise should not have resolved')
+    }, (err) => {
+      // We're not testing the specific text of the error message. We just check
+      // that it is an execution error.
+      t.equal(err.code, 'ENOENT')
+    })
+})


### PR DESCRIPTION
The problematic code prior to this PR is [this](https://github.com/zkat/pacote/blob/3b9e844231857b705b3c421ff761757a77fc37a5/extract.js#L50-L70):

```
function tryExtract (spec, tarStream, dest, opts) {
  return new BB((resolve, reject) => {
    tarStream.on('error', reject)
    setImmediate(resolve)
  })
    .then(() => rimraf(dest))
    .then(() => mkdirp(dest))
    .then(() => new BB((resolve, reject) => {
      const xtractor = extractStream(spec, dest, opts)
      tarStream.on('error', reject)
      xtractor.on('error', reject)
      xtractor.on('close', resolve)
      tarStream.pipe(xtractor)
    }))
    .catch(err => {
      if (err.code === 'EINTEGRITY') {
        err.message = `Verification failed while extracting ${spec}:\n${err.message}`
      }
      throw err
    })
}
```

There's a race condition in this code. The problem is that neither of the `tarStream.on('error', reject)` lines are capable of reporting all errors with `tarStream`. If a `tarStream` error happens prior to the outer `resolve` being called, then the first `tarStream.on('error'...` will pass the error up correctly. (Actually, I don't think this case is possible. At some point I had instrumented the callback passed to both calls to `tarStream.on('error'...`  and the callback passed to `setImmediate(...)`, and it never ever ever ever ever happened that the first `tarStream.on('error'` caught an error prior to the call scheduled with `setImmediate`.)

However, for those errors that cannot be detected immediately the first `tarStream.on('error'` call is useless. By the time these errors are raised, the `resolve` call scheduled by `setImmediate` will have happened, and thus even if the first `tarStream.on('error'` calls `reject`, this will have no effect whatsoever because the promise has already resolved.

So there is a window of time between the first `tarStream.on('error'` and the second one where if a `tarStream` error occurs, it won't be sent up the promise chain. How big a window it is depends on how long `rimraf` and `mkdirp` take to do their work. If a `tarStream` error is raised during that window, the first `error` event handler cannot do anything about it, and the 2nd event handler is not setup yet so it cannot do anything either.

The test I created to test the issue changes `PATH` to an empty string temporarily so that executing `git` will fail. It replicates the problem I initially ran into: I was running `npm` in a docker build where `git` was not installed, and I got the utterly non-descriptive `cb() never called` error message. (And nothing else. I've seen cases where `cb() never called` is accompanied with some more information but in my case that was the sole error message and `--loglevel=silly` did not help either.)